### PR TITLE
IDs de Proveedor y Contratista se averiguan desde el MID

### DIFF
--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -181,9 +181,7 @@ func (c *ActaRecibidoController) GetAllElementosConsumo() {
 // @Title Get All Actas
 // @Description get ActaRecibido
 // @Param	states	query	string	false	"If specified, returns only acts with the specified state(s) from ACTA_RECIBIDO_SERVICE / estado_acta, separated by commas"
-// @Param u query string false "WSO2 User"
-// @Param provId query int false "Proveedor Id - Use with WSO2 User"
-// @Param contrId query int false "Contratista Id - Use with WSO2 User"
+// @Param u query string false "WSO2 User. When specified, acts will be filtered upon the available roles for the specified user"
 // @Success 200 {object} []models.ActaRecibido
 // @Failure 400 "Wrong IDs"
 // @Failure 404 "not found resource"
@@ -247,7 +245,7 @@ func (c *ActaRecibidoController) GetAllActas() {
 		})
 	}
 
-	if l, err := actaRecibido.GetAllActasRecibidoActivas(reqStates, WSO2user, idContratista, idProveedor); err == nil {
+	if l, err := actaRecibido.GetAllActasRecibidoActivas(reqStates, WSO2user); err == nil {
 		// fmt.Print("DATA FINAL: ")
 		// fmt.Println(l)
 		c.Data["json"] = l

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -60,7 +60,7 @@ type Subgrupo struct {
 }
 
 // GetAllActasRecibido ...
-func GetAllActasRecibidoActivas(states []string, usrWSO2 string, contratista int, proveedor int) (historicoActa []map[string]interface{}, outputError map[string]interface{}) {
+func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa []map[string]interface{}, outputError map[string]interface{}) {
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -305,7 +305,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string, contratista int
 		// de la siguiente función, una vez sea uniforme el espacio de
 		// usuarios
 		if usrWSO2 != "" {
-			if actas, err := filtrarActasSegunRoles(historicoActa, usrWSO2, contratista, proveedor); err == nil {
+			if actas, err := filtrarActasSegunRoles(historicoActa, usrWSO2); err == nil {
 				historicoActa = actas
 			} else {
 				logs.Error(err)

--- a/helpers/proveedorHelper/poveedor.helper.go
+++ b/helpers/proveedorHelper/poveedor.helper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/udistrital/utils_oas/request"
 )
 
-// GetProveedorId ...
+// GetProveedorById Retorna los datos de un proveedor a partir del Id como proveedor
 func GetProveedorById(proveedorId int) (proveedor []*models.Proveedor, outputError map[string]interface{}) {
 
 	defer func() {
@@ -38,6 +38,37 @@ func GetProveedorById(proveedorId int) (proveedor []*models.Proveedor, outputErr
 	} else {
 		logs.Info("Error (1) Parametro")
 		outputError = map[string]interface{}{"funcion": "GetProveedorById", "err": "null parameter", "status": "400"}
+		return nil, outputError
+	}
+}
+
+// GetProveedorByDoc Retorna los datos de un proveedor a partir del # de documento
+func GetProveedorByDoc(docNum string) (proveedor []*models.Proveedor, outputError map[string]interface{}) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			outputError = map[string]interface{}{"funcion": "/GetProveedorByDoc", "err": err, "status": "502"}
+			panic(outputError)
+		}
+	}()
+
+	if docNum != "" { // (1) error parametro
+		if response, err := request.GetJsonTest("http://"+beego.AppConfig.String("administrativaService")+"informacion_proveedor?query=NumDocumento:"+docNum, &proveedor); err == nil { // (2) error servicio caido
+			if response.StatusCode == 200 { // (3) error estado de la solicitud
+				return proveedor, nil
+			} else {
+				outputError = map[string]interface{}{"funcion": "GetProveedorByDoc", "err": "Error (3) estado de la solicitud", "status": response.Status}
+				logs.Error(outputError)
+				return nil, outputError
+			}
+		} else {
+			outputError = map[string]interface{}{"funcion": "GetProveedorByDoc", "err": err, "status": "502"}
+			logs.Error(outputError)
+			return nil, outputError
+		}
+	} else {
+		outputError = map[string]interface{}{"funcion": "GetProveedorByDoc", "err": "Error (1) Parametro", "status": "400"}
+		logs.Error(outputError)
 		return nil, outputError
 	}
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -125,22 +125,8 @@
                     {
                         "in": "query",
                         "name": "u",
-                        "description": "WSO2 User",
+                        "description": "WSO2 User. When specified, acts will be filtered upon the available roles for the specified user",
                         "type": "string"
-                    },
-                    {
-                        "in": "query",
-                        "name": "provId",
-                        "description": "Proveedor Id - Use with WSO2 User",
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    {
-                        "in": "query",
-                        "name": "contrId",
-                        "description": "Contratista Id - Use with WSO2 User",
-                        "type": "integer",
-                        "format": "int64"
                     }
                 ],
                 "responses": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -86,18 +86,9 @@ paths:
         type: string
       - in: query
         name: u
-        description: WSO2 User
+        description: WSO2 User. When specified, acts will be filtered upon the available
+          roles for the specified user
         type: string
-      - in: query
-        name: provId
-        description: Proveedor Id - Use with WSO2 User
-        type: integer
-        format: int64
-      - in: query
-        name: contrId
-        description: Contratista Id - Use with WSO2 User
-        type: integer
-        format: int64
       responses:
         "200":
           description: ""


### PR DESCRIPTION
Relacionado con udistrital/arka_cliente#389

Antes se pasaban los IDs de proveedor y contratista en el query
/acta_recibido/get_all_actas/

Ahora, como se usa la MID API de Autenticación, se obtiene de esta el # de documento para con este hacer una consulta en la base de datos de proveedores

De los campos que se agregaron en #58 únicamente quedaron los estados y el usuario de WSO2:

![image](https://user-images.githubusercontent.com/6588872/104349861-7d2e0c80-54d1-11eb-9ef9-01ccd3f33561.png)

... con lo que se podría decir que toda la lógica de filtrado de actas implementada en udistrital/arka_cliente#363 se ejecuta directamente en el MID