### PR TITLE
Fix/bodega consumo

### DIFF
--- a/controllers/bodega_consumo.go
+++ b/controllers/bodega_consumo.go
@@ -20,8 +20,6 @@ func (c *BodegaConsumoController) URLMapping() {
 	c.Mapping("GetOne", c.GetOneSolicitud)
 	c.Mapping("GetAll", c.GetElementos)
 	c.Mapping("Get", c.GetAllExistencias)
-	
-
 }
 
 // GetOneSolicitud ...
@@ -82,7 +80,6 @@ func (c *BodegaConsumoController) GetAperturasKardex() {
 		c.Data["json"] = v
 	}
 	c.ServeJSON()
-
 
 }
 

--- a/controllers/bodega_consumo.go
+++ b/controllers/bodega_consumo.go
@@ -25,9 +25,12 @@ func (c *BodegaConsumoController) URLMapping() {
 // GetOneSolicitud ...
 // @Title GetOneSolicitud
 // @Description get Bodega-Consumo by id
-// @Param	id		path 	string	true		"The key for staticblock"
-// @Success 200 {object}{"Id": int,"FechaCreacion": date,"Observacion": string,"Elementos": {"Id": int,"Nombre":string,"Marca": string,"Serie": string,"CantidadDisponible": int,"CantidadSolicitada": int,	"ValorUnitario": float,} }
-// @Failure 403 :id is empty
+// @Param	id		path 	uint	true		"MovimientoId from Movimientos Arka CRUD"
+// @Success 200 {object} models.BodegaConsumoSolicitud
+// @Failure 400 "Wrong parameter (ID MUST be > 0)"
+// @Failure 404 "Not found"
+// @Failure 500 "Internal Error"
+// @Failure 502 "Error with external API"
 // @router /solicitud/:id [get]
 func (c *BodegaConsumoController) GetOneSolicitud() {
 

--- a/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
+++ b/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
@@ -33,8 +33,9 @@ func GetSolicitudById(id int) (Solicitud map[string]interface{}, outputError map
 	logs.Debug(url)
 	if res, err := request.GetJsonTest(url, &solicitud_); err == nil && res.StatusCode == 200 {
 
-		// TO-DO: Arreglar el CRUD! No debería retornar un arreglo con un elemento vacío
-		// Por máximo debería retornar el arreglo vacío!
+		// TO-DO: Arreglar el CRUD! No debería retornar un arreglo con un elemento vacío ([{}])
+		// Por máximo debería retornar el arreglo vacío! (sin el objeto vacío, [])
+		// (Y uno de los siguientes estados: 204 o 404)
 		if len(solicitud_) == 0 || len(solicitud_[0]) == 0 {
 			err := fmt.Errorf("Movimiento %d no encontrado", id)
 			logs.Error(err)

--- a/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
+++ b/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
@@ -3,6 +3,7 @@ package bodegaConsumoHelper
 import (
 	"encoding/json"
 	"fmt"
+
 	// "strconv"
 	"strings"
 	// "reflect"
@@ -19,14 +20,13 @@ func GetSolicitudById(id int) (Solicitud map[string]interface{}, err error) {
 	var solicitud_ []map[string]interface{}
 	var elementos___ []map[string]interface{}
 
-	url := "http://" + beego.AppConfig.String("movimientosArkaService") + "movimiento?query=Id:"+ fmt.Sprintf("%v", id) + ""
+	url := "http://" + beego.AppConfig.String("movimientosArkaService") + "movimiento?query=Id:" + fmt.Sprintf("%v", id) + ""
 	if _, err := request.GetJsonTest(url, &solicitud_); err == nil {
 
-			
 		str := fmt.Sprintf("%v", solicitud_[0]["Detalle"])
 		var data map[string]interface{}
 		if err := json.Unmarshal([]byte(str), &data); err == nil {
-		
+
 			fmt.Println(data)
 			if tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data["Funcionario"])); err == nil {
 				solicitud_[0]["Funcionario"] = tercero
@@ -49,7 +49,7 @@ func GetSolicitudById(id int) (Solicitud map[string]interface{}, err error) {
 							} else {
 								Elemento__["CantidadAprobada"] = 0
 							}
-							
+
 							elementos___ = append(elementos___, Elemento__)
 						} else {
 							panic(err.Error())
@@ -60,7 +60,7 @@ func GetSolicitudById(id int) (Solicitud map[string]interface{}, err error) {
 						"Solicitud": solicitud_,
 						"Elementos": elementos___,
 					}
-		
+
 					return Solicitud, nil
 
 				} else {
@@ -89,11 +89,11 @@ func TraerElementoSolicitud(Elemento map[string]interface{}) (Elemento_ map[stri
 	var sede []map[string]interface{}
 
 	fmt.Println("elemento asdasdadasdfasd: ", Elemento)
-	
+
 	if _, err := request.GetJsonTest(urlcrud3, &ubicacion); err == nil {
-		
+
 		ubicacion2 := ubicacion[0]["EspacioFisicoId"].(map[string]interface{})
-		
+
 		z := strings.Split(fmt.Sprintf("%v", ubicacion2["CodigoAbreviacion"]), "")
 
 		urlcrud4 := "http://" + beego.AppConfig.String("oikos2Service") + "espacio_fisico?query=CodigoAbreviacion:" + z[0] + z[1] + z[2] + z[3]
@@ -117,13 +117,12 @@ func TraerElementoSolicitud(Elemento map[string]interface{}) (Elemento_ map[stri
 			panic(err.Error())
 			return nil, err
 		}
-	
+
 	} else {
 		panic(err.Error())
 		return nil, err
 	}
-	
-	
+
 }
 
 func GetElementosSinAsignar() (Elementos []map[string]interface{}, err error) {
@@ -137,16 +136,16 @@ func GetElementosSinAsignar() (Elementos []map[string]interface{}, err error) {
 				var detalle []map[string]interface{}
 				url2 := "http://" + beego.AppConfig.String("actaRecibidoService") + "elemento?query=Id:" + fmt.Sprintf("%v", elemento["ElementoActaId"]) + "&fields=Id,Nombre,Marca,Serie,SubgrupoCatalogoId"
 				if _, err := request.GetJsonTest(url2, &detalle); err == nil {
-	
+
 					var subgrupo []map[string]interface{}
 					url3 := "http://" + beego.AppConfig.String("catalogoElementosService") + "subgrupo?query=Id:" + fmt.Sprintf("%v", detalle[0]["SubgrupoCatalogoId"])
 					if _, err := request.GetJsonTest(url3, &subgrupo); err == nil {
-					
+
 						Elementos[i]["Nombre"] = detalle[0]["Nombre"]
 						Elementos[i]["Marca"] = detalle[0]["Marca"]
 						Elementos[i]["Serie"] = detalle[0]["Serie"]
 						Elementos[i]["SubgrupoCatalogoId"] = subgrupo[0]
-						
+
 					} else {
 						panic(err.Error())
 						return nil, err
@@ -156,7 +155,7 @@ func GetElementosSinAsignar() (Elementos []map[string]interface{}, err error) {
 					return nil, err
 				}
 			}
-	
+
 			return Elementos, nil
 		} else {
 			return Elementos, nil
@@ -173,8 +172,7 @@ func GetAperturasKardex() (Elementos []map[string]interface{}, err error) {
 	var Elementos___ []map[string]interface{}
 	url := "http://" + beego.AppConfig.String("movimientosArkaService") + "elementos_movimiento?query=MovimientoId.FormatoTipoMovimientoId.CodigoAbreviacion:AP_KDX&limit=-1"
 	if _, err := request.GetJsonTest(url, &Elementos___); err == nil {
-		fmt.Println("Elementos___",Elementos___)
-
+		fmt.Println("Elementos___", Elementos___)
 
 		if keys := len(Elementos___[0]); keys != 0 {
 			for _, elemento := range Elementos___ {
@@ -182,39 +180,38 @@ func GetAperturasKardex() (Elementos []map[string]interface{}, err error) {
 				fmt.Println("Elemento", elemento)
 				var data map[string]interface{}
 				if jsonString, err := json.Marshal(elemento["MovimientoId"]); err == nil {
-					fmt.Println("Movimiento",jsonString)
-	
+					fmt.Println("Movimiento", jsonString)
+
 					if err2 := json.Unmarshal(jsonString, &data); err2 == nil {
 						fmt.Println("DetalleMovimiento", data)
-	
+
 						str := fmt.Sprintf("%v", data["Detalle"])
 						var data2 map[string]interface{}
 						if err := json.Unmarshal([]byte(str), &data2); err == nil {
-							fmt.Println("Detalle",data2)
-	
-							
+							fmt.Println("Detalle", data2)
+
 							var elemento_catalogo []map[string]interface{}
 							url3 := "http://" + beego.AppConfig.String("catalogoElementosService") + "elemento?query=Id:" + fmt.Sprintf("%v", elemento["ElementoCatalogoId"])
 							if _, err := request.GetJsonTest(url3, &elemento_catalogo); err == nil {
-	
+
 								Elemento := map[string]interface{}{
-									"MetodoValoracion":		data2["Metodo_Valoracion"],
-									"CantidadMinima":		data2["Cantidad_Minima"],
-									"CantidadMaxima": 		data2["Cantidad_Maxima"],
-									"FechaCreacion":		elemento["FechaCreacion"],
-									"Observaciones":		data["Observacion"],
-									"Id":					data["Id"],
-									"MovimientoPadreId":	data["MovimientoPadreId"],
-									"ElementoCatalogoId":	elemento_catalogo[0],
+									"MetodoValoracion":   data2["Metodo_Valoracion"],
+									"CantidadMinima":     data2["Cantidad_Minima"],
+									"CantidadMaxima":     data2["Cantidad_Maxima"],
+									"FechaCreacion":      elemento["FechaCreacion"],
+									"Observaciones":      data["Observacion"],
+									"Id":                 data["Id"],
+									"MovimientoPadreId":  data["MovimientoPadreId"],
+									"ElementoCatalogoId": elemento_catalogo[0],
 								}
-								
+
 								Elementos = append(Elementos, Elemento)
-	
+
 							} else {
 								panic(err.Error())
 								return nil, err
 							}
-							
+
 						} else {
 							panic(err.Error())
 							return nil, err
@@ -227,15 +224,14 @@ func GetAperturasKardex() (Elementos []map[string]interface{}, err error) {
 					panic(err.Error())
 					return nil, err
 				}
-				
+
 			}
-	
+
 			return Elementos, nil
 		} else {
 			return Elementos___, nil
-		} 
+		}
 
-		
 	} else {
 		panic(err.Error())
 		return nil, err
@@ -247,11 +243,10 @@ func GetExistenciasKardex() (Elementos []map[string]interface{}, err error) {
 	var Elementos___ []map[string]interface{}
 	url := "http://" + beego.AppConfig.String("movimientosArkaService") + "elementos_movimiento?query=MovimientoId.FormatoTipoMovimientoId.CodigoAbreviacion:AP_KDX,Activo:true&limit=-1&fields=ElementoCatalogoId"
 	if _, err := request.GetJsonTest(url, &Elementos___); err == nil {
-		fmt.Println("Elementos",Elementos___[0])
-
+		fmt.Println("Elementos", Elementos___[0])
 
 		if keys := len(Elementos___[0]); keys != 0 {
-			
+
 			for _, elemento := range Elementos___ {
 
 				if Elemento, err := UltimoMovimientoKardex(fmt.Sprintf("%v", elemento["ElementoCatalogoId"])); err == nil {
@@ -259,16 +254,14 @@ func GetExistenciasKardex() (Elementos []map[string]interface{}, err error) {
 				} else {
 					panic(err.Error())
 					return nil, err
-				}	
+				}
 			}
-	
+
 			return Elementos, nil
-		} else  {
-			
+		} else {
+
 			return Elementos___, nil
 		}
-
-		
 
 	} else {
 		panic(err.Error())
@@ -276,7 +269,7 @@ func GetExistenciasKardex() (Elementos []map[string]interface{}, err error) {
 	}
 }
 
-func UltimoMovimientoKardex(id_catalogo string)(Elemento_Movimiento map[string]interface{}, err error) {
+func UltimoMovimientoKardex(id_catalogo string) (Elemento_Movimiento map[string]interface{}, err error) {
 
 	var elemento_catalogo []map[string]interface{}
 

--- a/helpers/tercerosHelper/tercero.helper.go
+++ b/helpers/tercerosHelper/tercero.helper.go
@@ -55,9 +55,9 @@ func GetNombreTerceroById2(idTercero string) (tercero map[string]interface{}, er
 				} else {
 					fmt.Println("encargado: ", element)
 					return map[string]interface{}{
-						"Id":				idTercero,
-						"Numero":         	element["Numero"],
-						"NombreCompleto": 	element["TerceroId"].(map[string]interface{})["NombreCompleto"],
+						"Id":             idTercero,
+						"Numero":         element["Numero"],
+						"NombreCompleto": element["TerceroId"].(map[string]interface{})["NombreCompleto"],
 					}, nil
 				}
 

--- a/models/bodega_consumo.go
+++ b/models/bodega_consumo.go
@@ -1,0 +1,26 @@
+package models
+
+type BodegaConsumoSolicitud struct {
+	Elementos *ElementoSolicitud
+	Solicitud *Movimiento
+}
+
+type ElementoSolicitud struct {
+	Cantidad           uint
+	CantidadAprobada   uint
+	ElementoCatalogoId *ElementoCatalogo
+	Id                 uint
+	Nombre             string
+	SaldoCantidad      uint
+	SaldoValor         uint
+	Sede               *EspacioFisico
+	Dependencia        *Dependencia
+	Ubicacion          *AsignacionEspacioFisicoDependencia
+}
+
+type ElementoCatalogo struct {
+	Id          uint
+	Nombre      string
+	Descripcion string
+	Activo      bool
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -372,17 +372,30 @@
                     {
                         "in": "path",
                         "name": "id",
-                        "description": "The key for staticblock",
+                        "description": "MovimientoId from Movimientos Arka CRUD",
                         "required": true,
-                        "type": "string"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "{object}{\"Id\": int,\"FechaCreacion\": date,\"Observacion\": string,\"Elementos\": {\"Id\": int,\"Nombre\":string,\"Marca\": string,\"Serie\": string,\"CantidadDisponible\": int,\"CantidadSolicitada\": int,\t\"ValorUnitario\": float,} }"
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/models.BodegaConsumoSolicitud"
+                        }
                     },
-                    "403": {
-                        "description": ":id is empty"
+                    "400": {
+                        "description": "\"Wrong parameter (ID MUST be \u003e 0)\""
+                    },
+                    "404": {
+                        "description": "\"Not found\""
+                    },
+                    "500": {
+                        "description": "\"Internal Error\""
+                    },
+                    "502": {
+                        "description": "\"Error with external API\""
                     }
                 }
             }
@@ -1007,6 +1020,18 @@
             "title": "Bodega-Consumo",
             "type": "object"
         },
+        "models.BodegaConsumoSolicitud": {
+            "title": "BodegaConsumoSolicitud",
+            "type": "object",
+            "properties": {
+                "Elementos": {
+                    "$ref": "#/definitions/models.ElementoSolicitud"
+                },
+                "Solicitud": {
+                    "$ref": "#/definitions/models.Movimiento"
+                }
+            }
+        },
         "models.ConsultaEntrada": {
             "title": "ConsultaEntrada",
             "type": "object",
@@ -1237,6 +1262,66 @@
                 },
                 "Verificado": {
                     "type": "boolean"
+                }
+            }
+        },
+        "models.ElementoCatalogo": {
+            "title": "ElementoCatalogo",
+            "type": "object",
+            "properties": {
+                "Activo": {
+                    "type": "boolean"
+                },
+                "Descripcion": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "Nombre": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.ElementoSolicitud": {
+            "title": "ElementoSolicitud",
+            "type": "object",
+            "properties": {
+                "Cantidad": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "CantidadAprobada": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "Dependencia": {
+                    "$ref": "#/definitions/models.Dependencia"
+                },
+                "ElementoCatalogoId": {
+                    "$ref": "#/definitions/models.ElementoCatalogo"
+                },
+                "Id": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "Nombre": {
+                    "type": "string"
+                },
+                "SaldoCantidad": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "SaldoValor": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "Sede": {
+                    "$ref": "#/definitions/models.EspacioFisico"
+                },
+                "Ubicacion": {
+                    "$ref": "#/definitions/models.AsignacionEspacioFisicoDependencia"
                 }
             }
         },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -289,17 +289,23 @@ paths:
       parameters:
       - in: path
         name: id
-        description: The key for staticblock
+        description: MovimientoId from Movimientos Arka CRUD
         required: true
-        type: string
+        type: integer
+        format: int32
       responses:
         "200":
-          description: "{object}{\"Id\": int,\"FechaCreacion\": date,\"Observacion\":
-            string,\"Elementos\": {\"Id\": int,\"Nombre\":string,\"Marca\": string,\"Serie\":
-            string,\"CantidadDisponible\": int,\"CantidadSolicitada\": int,\t\"ValorUnitario\":
-            float,} }"
-        "403":
-          description: :id is empty
+          description: ""
+          schema:
+            $ref: '#/definitions/models.BodegaConsumoSolicitud'
+        "400":
+          description: '"Wrong parameter (ID MUST be > 0)"'
+        "404":
+          description: '"Not found"'
+        "500":
+          description: '"Internal Error"'
+        "502":
+          description: '"Error with external API"'
   /catalogo_elementos/:
     post:
       tags:
@@ -676,6 +682,14 @@ definitions:
   models.Bodega-Consumo:
     title: Bodega-Consumo
     type: object
+  models.BodegaConsumoSolicitud:
+    title: BodegaConsumoSolicitud
+    type: object
+    properties:
+      Elementos:
+        $ref: '#/definitions/models.ElementoSolicitud'
+      Solicitud:
+        $ref: '#/definitions/models.Movimiento'
   models.ConsultaEntrada:
     title: ConsultaEntrada
     type: object
@@ -842,6 +856,48 @@ definitions:
         format: double
       Verificado:
         type: boolean
+  models.ElementoCatalogo:
+    title: ElementoCatalogo
+    type: object
+    properties:
+      Activo:
+        type: boolean
+      Descripcion:
+        type: string
+      Id:
+        type: integer
+        format: int32
+      Nombre:
+        type: string
+  models.ElementoSolicitud:
+    title: ElementoSolicitud
+    type: object
+    properties:
+      Cantidad:
+        type: integer
+        format: int32
+      CantidadAprobada:
+        type: integer
+        format: int32
+      Dependencia:
+        $ref: '#/definitions/models.Dependencia'
+      ElementoCatalogoId:
+        $ref: '#/definitions/models.ElementoCatalogo'
+      Id:
+        type: integer
+        format: int32
+      Nombre:
+        type: string
+      SaldoCantidad:
+        type: integer
+        format: int32
+      SaldoValor:
+        type: integer
+        format: int32
+      Sede:
+        $ref: '#/definitions/models.EspacioFisico'
+      Ubicacion:
+        $ref: '#/definitions/models.AsignacionEspacioFisicoDependencia'
   models.ElementosMovimiento:
     title: ElementosMovimiento
     type: object


### PR DESCRIPTION
Closes udistrital/arka_cliente#410

Validaciones adicionales cuando un Query a una API externa retorna un arreglo con un objeto vacío (`[{}]`)

A futuro debería asegurarse que cuando una API NO retorne resultados, debería validarse que por máximo retornen un arreglo vacío (`[]`)

E independientemente del valor de retorno, que el código de retorno sea 204 o 404