### PR TITLE
Fix/elementos

### DIFF
--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -98,8 +98,12 @@ func (c *ActaRecibidoController) GetActasByTipo() {
 // @Title Get Elementos
 // @Description get Elementos by id
 // @Param	id		path 	int	true		"id del acta"
-// @Success 200 {object} models.Elemento
+// @Success 200 {object} []models.Elemento
+// @Success 204 Empty response (Due to Act not found or without elements)
+// @Failure 400 Wrong ID (MUST be greater than 0)
 // @Failure 404 not found resource
+// @Failure 500 Internal Error
+// @Failure 502 Error with external API
 // @router /get_elementos_acta/:id [get]
 func (c *ActaRecibidoController) GetElementosActa() {
 
@@ -112,7 +116,7 @@ func (c *ActaRecibidoController) GetElementosActa() {
 			if status, ok := localError["status"]; ok {
 				c.Abort(status.(string))
 			} else {
-				c.Abort("404")
+				c.Abort("500") // Unhandled Error!
 			}
 		}
 	}()
@@ -122,11 +126,15 @@ func (c *ActaRecibidoController) GetElementosActa() {
 	if idTest, err := strconv.Atoi(idStr); err == nil && idTest > 0 {
 		id = idTest
 	} else if err != nil {
-		panic(err)
+		panic(map[string]interface{}{
+			"funcion": "GetElementosActa",
+			"err":     err,
+			"status":  "400",
+		})
 	} else {
 		panic(map[string]interface{}{
 			"funcion": "GetElementosActa",
-			"err":     "The Id MUST be > 0",
+			"err":     "The Id MUST be greater than 0",
 			"status":  "400",
 		})
 	}

--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -107,7 +107,7 @@ func (c *ActaRecibidoController) GetElementosActa() {
 		if err := recover(); err != nil {
 			logs.Error(err)
 			localError := err.(map[string]interface{})
-			c.Data["mesaage"] = (beego.AppConfig.String("appname") + "/" + "ActaRecibidoController" + "/" + (localError["funcion"]).(string))
+			c.Data["message"] = (beego.AppConfig.String("appname") + "/" + "ActaRecibidoController" + "/" + (localError["funcion"]).(string))
 			c.Data["data"] = (localError["err"])
 			if status, ok := localError["status"]; ok {
 				c.Abort(status.(string))
@@ -119,10 +119,16 @@ func (c *ActaRecibidoController) GetElementosActa() {
 
 	idStr := c.Ctx.Input.Param(":id")
 	var id int
-	if idTest, err := strconv.Atoi(idStr); err == nil {
+	if idTest, err := strconv.Atoi(idStr); err == nil && idTest > 0 {
 		id = idTest
-	} else {
+	} else if err != nil {
 		panic(err)
+	} else {
+		panic(map[string]interface{}{
+			"funcion": "GetElementosActa",
+			"err":     "The Id MUST be > 0",
+			"status":  "400",
+		})
 	}
 	// fmt.Printf("id: %v\n", id)
 

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -752,7 +752,6 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 					"status":  "204",
 				}
 				return nil, outputError
-				return elementosActa, nil
 			}
 
 			for k, elemento := range elementos {

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -744,14 +744,14 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 			// fmt.Printf("#Elementos: %v\n", len(elementos))
 
 			if len(elementos) == 0 || elementos[0].Id == 0 {
-				err := fmt.Errorf("No elements for Act #%d", actaId)
+				err := fmt.Errorf("No elements for Act #%d (or Act not found)", actaId)
 				logs.Warn(err)
-				// outputError = map[string]interface{}{
-				// 	"funcion": "/GetElementos - len(elementos) == 0 || elementos[0].Id == 0",
-				// 	"err":     err,
-				// 	"status":  "204",
-				// }
-				// return nil, outputError
+				outputError = map[string]interface{}{
+					"funcion": "/GetElementos - len(elementos) == 0 || elementos[0].Id == 0",
+					"err":     err,
+					"status":  "204",
+				}
+				return nil, outputError
 				return elementosActa, nil
 			}
 

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -742,6 +742,19 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 			// Solicita información unidad elemento
 			// urlcrud = "http://" + beego.AppConfig.String("administrativaService") + "/unidad/"
 			// fmt.Printf("#Elementos: %v\n", len(elementos))
+
+			if len(elementos) == 0 || elementos[0].Id == 0 {
+				err := fmt.Errorf("No elements for Act #%d", actaId)
+				logs.Warn(err)
+				// outputError = map[string]interface{}{
+				// 	"funcion": "/GetElementos - len(elementos) == 0 || elementos[0].Id == 0",
+				// 	"err":     err,
+				// 	"status":  "204",
+				// }
+				// return nil, outputError
+				return elementosActa, nil
+			}
+
 			for k, elemento := range elementos {
 				fmt.Printf("#Elemento: %v\n", k)
 

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -720,9 +720,9 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "/GetElementos",
+				"funcion": "/GetElementos - Unhandled Error!",
 				"err":     err,
-				"status":  "502",
+				"status":  "500",
 			}
 			panic(outputError)
 		}
@@ -734,7 +734,7 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 		auxE      models.ElementosActa
 		soporte   *models.SoporteActaProveedor
 	)
-	if actaId != 0 { // (1) error parametro
+	if actaId > 0 { // (1) error parametro
 		// Solicita información elementos acta
 		urlcrud = "http://" + beego.AppConfig.String("actaRecibidoService") + "elemento?query=SoporteActaId.ActaRecibidoId.Id:" + strconv.Itoa(actaId) +
 			",Activo:True&limit=-1"
@@ -750,38 +750,58 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 				auxE.Cantidad = elemento.Cantidad
 				auxE.Marca = elemento.Marca
 				auxE.Serie = elemento.Serie
-				// UNIDAD DEMEDIDA
-				if unidad, err2 := unidadHelper.GetUnidad(elemento.UnidadMedida); err2 == nil && len(unidad) > 0 {
-					auxE.UnidadMedida = unidad[0]
-				} else if err2 != nil {
-					return nil, err2
-				} else {
-					outputError = map[string]interface{}{
-						"funcion": "/GetElementos",
-						"err":     err2,
-						"status":  "502",
+
+				// UNIDAD DE MEDIDA
+				if elemento.UnidadMedida > 0 {
+					if unidad, err := unidadHelper.GetUnidad(elemento.UnidadMedida); err == nil && len(unidad) > 0 {
+						auxE.UnidadMedida = unidad[0]
+					} else if err != nil {
+						logs.Error(err)
+						outputError = map[string]interface{}{
+							"funcion": "/GetElementos - unidadHelper.GetUnidad(elemento.UnidadMedida)",
+							"err":     err,
+							"status":  "502",
+						}
+						return nil, outputError
+					} else {
+						err := fmt.Errorf("UnidadMedida '%d' Not Found", elemento.UnidadMedida)
+						logs.Error(err)
+						outputError = map[string]interface{}{
+							"funcion": "/GetElementos - unidadHelper.GetUnidad(elemento.UnidadMedida) / len(unidad) > 0",
+							"err":     err,
+							"status":  "502",
+						}
+						return nil, outputError
 					}
-					logs.Error(outputError)
-					return nil, outputError
 				}
 
 				auxE.ValorUnitario = elemento.ValorUnitario
 				auxE.Subtotal = elemento.Subtotal
 				auxE.Descuento = elemento.Descuento
 				auxE.ValorTotal = elemento.ValorTotal
+
 				// PORCENTAJE IVA
-				if iva, err2 := parametrosGobiernoHelper.GetIva(elemento.PorcentajeIvaId); err2 == nil && len(iva) > 0 {
-					auxE.PorcentajeIvaId = iva[0]
-				} else if err2 != nil {
-					return nil, err2
-				} else {
-					outputError = map[string]interface{}{
-						"funcion": "/GetElementos",
-						"err":     err2,
-						"status":  "502",
+				if elemento.PorcentajeIvaId > 0 {
+					if iva, err := parametrosGobiernoHelper.GetIva(elemento.PorcentajeIvaId); err == nil && len(iva) > 0 {
+						auxE.PorcentajeIvaId = iva[0]
+					} else if err != nil {
+						logs.Error(err)
+						outputError = map[string]interface{}{
+							"funcion": "/GetElementos - parametrosGobiernoHelper.GetIva(elemento.PorcentajeIvaId)",
+							"err":     err,
+							"status":  "502",
+						}
+						return nil, outputError
+					} else {
+						err := fmt.Errorf("PorcentajeIvaId '%d' Not Found", elemento.PorcentajeIvaId)
+						logs.Error(err)
+						outputError = map[string]interface{}{
+							"funcion": "/GetElementos - parametrosGobiernoHelper.GetIva(elemento.PorcentajeIvaId)",
+							"err":     err,
+							"status":  "500",
+						}
+						return nil, outputError
 					}
-					logs.Error(outputError)
-					return nil, outputError
 				}
 
 				auxE.ValorIva = elemento.ValorIva
@@ -792,22 +812,31 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 				auxE.EstadoElementoId = elemento.EstadoElementoId
 				// SOPORTE
 				soporte = new(models.SoporteActaProveedor)
+
 				if elemento.SoporteActaId.ProveedorId > 0 {
-					if proveedor, err2 := proveedorHelper.GetProveedorById(elemento.SoporteActaId.ProveedorId); err2 == nil && len(proveedor) > 0 {
+					if proveedor, err := proveedorHelper.GetProveedorById(elemento.SoporteActaId.ProveedorId); err == nil && len(proveedor) > 0 {
 						fmt.Printf("proveedor: %#v\n", proveedor[0])
 						soporte.ProveedorId = proveedor[0]
-					} else if err2 != nil {
-						return nil, err2
-					} else {
+					} else if err != nil {
+						logs.Error(err)
 						outputError = map[string]interface{}{
-							"funcion": "/GetElementos",
-							"err":     err2,
+							"funcion": "/GetElementos - proveedorHelper.GetProveedorById(elemento.SoporteActaId.ProveedorId)",
+							"err":     err,
 							"status":  "502",
 						}
-						logs.Error(outputError)
+						return nil, outputError
+					} else {
+						err := fmt.Errorf("ProveedorId '%d' Not Found", elemento.SoporteActaId.ProveedorId)
+						logs.Error(err)
+						outputError = map[string]interface{}{
+							"funcion": "/GetElementos - proveedorHelper.GetProveedorById(elemento.SoporteActaId.ProveedorId)",
+							"err":     err,
+							"status":  "500",
+						}
 						return nil, outputError
 					}
 				}
+
 				soporte.Id = elemento.SoporteActaId.Id
 				soporte.ActaRecibidoId = elemento.SoporteActaId.ActaRecibidoId
 				soporte.Consecutivo = elemento.SoporteActaId.Consecutivo
@@ -827,18 +856,31 @@ func GetElementos(actaId int) (elementosActa []models.ElementosActa, outputError
 			}
 
 			return elementosActa, nil
-		} else {
-			// logs.Info("Error (2) servicio caido")
+		} else if err != nil {
 			logs.Error(err)
-			outputError = map[string]interface{}{"funcion": "/GetElementos", "err": err, "status": "502"}
+			outputError = map[string]interface{}{
+				"funcion": "/GetElementos - request.GetJsonTest(urlcrud, &elementos)",
+				"err":     err,
+				"status":  "502", // Error (2) servicio caido
+			}
+			return nil, outputError
+		} else {
+			err := fmt.Errorf("Undesired State: %d", response.StatusCode)
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "/GetElementos - request.GetJsonTest(urlcrud, &elementos)",
+				"err":     err,
+				"status":  "500",
+			}
 			return nil, outputError
 		}
 	} else {
-		// logs.Info("Error (1) Parametro")
+		err := errors.New("ID must be greater than 0")
+		logs.Error(err)
 		outputError = map[string]interface{}{
-			"funcion": "/GetElementos",
-			"err":     "Error (1) Parametro",
-			"status":  "502",
+			"funcion": "/GetElementos - actaId > 0",
+			"err":     err,
+			"status":  "400",
 		}
 		return nil, outputError
 	}

--- a/helpers/parametrosGobiernoHelper/parametrosGobierno.helper.go
+++ b/helpers/parametrosGobiernoHelper/parametrosGobierno.helper.go
@@ -1,6 +1,7 @@
 package parametrosGobiernoHelper
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/astaxie/beego"
@@ -11,24 +12,51 @@ import (
 
 // GetIva ...
 func GetIva(ivaId int) (iva []*models.ParametrosGobierno, outputError map[string]interface{}) {
-	if ivaId != 0 { // (1) error parametro
 
-		if response, err := request.GetJsonTest("http://"+beego.AppConfig.String("parametrosGobiernoService")+"vigencia_impuesto?query=Id:"+strconv.Itoa(ivaId), &iva); err == nil { // (2) error servicio caido
+	defer func() {
+		if err := recover(); err != nil {
+			outputError = map[string]interface{}{
+				"funcion": "/GetIva - Unhandled Error!",
+				"err":     err,
+				"status":  "500",
+			}
+			panic(outputError)
+		}
+	}()
+
+	if ivaId > 0 { // (1) error parametro
+
+		urlParametroIVA := "http://" + beego.AppConfig.String("parametrosGobiernoService") + "vigencia_impuesto?query=Id:" + strconv.Itoa(ivaId)
+		if response, err := request.GetJsonTest(urlParametroIVA, &iva); err == nil { // (2) error servicio caido
 			if response.StatusCode == 200 { // (3) error estado de la solicitud
 				return iva, nil
 			} else {
-				logs.Info("Error (3) estado de la solicitud")
-				outputError = map[string]interface{}{"Function": "GetIva:GetIva", "Error": response.Status}
+				err := fmt.Errorf("Undesired Status: %s", response.Status)
+				logs.Error(err)
+				outputError = map[string]interface{}{
+					"funcion": "GetIva - request.GetJsonTest(urlParametroIVA, &iva)",
+					"err":     err,
+					"status":  "500",
+				}
 				return nil, outputError
 			}
 		} else {
-			logs.Info("Error (2) servicio caido")
-			outputError = map[string]interface{}{"Function": "GetIva", "Error": err}
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "GetIva - request.GetJsonTest(urlParametroIVA, &iva)",
+				"err":     err,
+				"status":  "502",
+			}
 			return nil, outputError
 		}
 	} else {
-		logs.Info("Error (1) Parametro")
-		outputError = map[string]interface{}{"Function": "FuncionalidadMidController:GetIva", "Error": "null parameter"}
+		err := fmt.Errorf("ivaId MUST be greater than 0")
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "FuncionalidadMidController:GetIva",
+			"err":     err,
+			"status":  "400",
+		}
 		return nil, outputError
 	}
 }

--- a/helpers/proveedorHelper/poveedor.helper.go
+++ b/helpers/proveedorHelper/poveedor.helper.go
@@ -1,6 +1,7 @@
 package proveedorHelper
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/astaxie/beego"
@@ -14,30 +15,48 @@ func GetProveedorById(proveedorId int) (proveedor []*models.Proveedor, outputErr
 
 	defer func() {
 		if err := recover(); err != nil {
-			outputError = map[string]interface{}{"funcion": "/GetProveedorById", "err": err, "status": "502"}
+			outputError = map[string]interface{}{
+				"funcion": "/GetProveedorById - Unhandled Error!",
+				"err":     err,
+				"status":  "500",
+			}
 			panic(outputError)
 		}
 	}()
 
-	if proveedorId != 0 { // (1) error parametro
+	if proveedorId > 0 { // (1) error parametro
 
-		if response, err := request.GetJsonTest("http://"+beego.AppConfig.String("administrativaService")+"informacion_proveedor?query=Id:"+strconv.Itoa(proveedorId), &proveedor); err == nil { // (2) error servicio caido
+		urlProveedor := "http://" + beego.AppConfig.String("administrativaService") + "informacion_proveedor?query=Id:" + strconv.Itoa(proveedorId)
+		if response, err := request.GetJsonTest(urlProveedor, &proveedor); err == nil { // (2) error servicio caido
 			if response.StatusCode == 200 { // (3) error estado de la solicitud
 				return proveedor, nil
 			} else {
-				logs.Info("Error (3) estado de la solicitud")
-				outputError = map[string]interface{}{"funcion": "GetProveedorById", "err": response.Status, "status": response.Status}
+				err := fmt.Errorf("Undesired Status: %s", response.Status)
+				logs.Error(err)
+				outputError = map[string]interface{}{
+					"funcion": "GetProveedorById - request.GetJsonTest(urlProveedor, &proveedor)",
+					"err":     err,
+					"status":  "500", // Error (3) estado de la solicitud
+				}
 				return nil, outputError
 			}
 		} else {
-			logs.Debug(err)
-			logs.Info("Error (2) servicio caido")
-			outputError = map[string]interface{}{"funcion": "GetProveedorById", "err": err, "status": "502"}
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "GetProveedorById - request.GetJsonTest(urlProveedor, &proveedor)",
+				"err":     err,
+				"status":  "502", // Error (2) servicio caido
+			}
 			return nil, outputError
 		}
 	} else {
-		logs.Info("Error (1) Parametro")
-		outputError = map[string]interface{}{"funcion": "GetProveedorById", "err": "null parameter", "status": "400"}
+		err := fmt.Errorf("proveedorId MUST be greater than 0")
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "GetProveedorById - proveedorId > 0",
+			"err":     err,
+			"status":  "400", // (1) error parametro
+		}
 		return nil, outputError
 	}
 }

--- a/helpers/unidadHelper/unidad.helper.go
+++ b/helpers/unidadHelper/unidad.helper.go
@@ -1,6 +1,7 @@
 package unidadHelper
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/astaxie/beego"
@@ -12,26 +13,53 @@ import (
 
 // GetUnidad ...
 func GetUnidad(unidadId int) (unidad []*models.Unidad, outputError map[string]interface{}) {
-	if unidadId != 0 { // (1) error parametro
+	if unidadId > 0 { // (1) error parametro
+
+		defer func() {
+			if err := recover(); err != nil {
+				outputError = map[string]interface{}{
+					"funcion": "/GetUnidad - Unhandled Error!",
+					"err":     err,
+					"status":  "500",
+				}
+				panic(outputError)
+			}
+		}()
+
 		var unidadAux *models.Unidad
 
-		if response, err := request.GetJsonTest("http://"+beego.AppConfig.String("administrativaService")+"unidad/"+strconv.Itoa(unidadId), &unidadAux); err == nil { // (2) error servicio caido
+		urlUnidad := "http://" + beego.AppConfig.String("administrativaService") + "unidad/" + strconv.Itoa(unidadId)
+		if response, err := request.GetJsonTest(urlUnidad, &unidadAux); err == nil { // (2) error servicio caido
 			if response.StatusCode == 200 { // (3) error estado de la solicitud
 				unidad = append(unidad, unidadAux)
 				return unidad, nil
 			} else {
-				logs.Info("Error (3) estado de la solicitud")
-				outputError = map[string]interface{}{"Function": "GetUnidad:GetUnidad", "Error": response.Status}
+				err := fmt.Errorf("Undesired Status: %s", response.Status)
+				logs.Error(err)
+				outputError = map[string]interface{}{
+					"funcion": "GetUnidad - request.GetJsonTest(urlUnidad, &unidadAux) / response.StatusCode == 200",
+					"err":     err,
+					"status":  "500", // Error (3) estado de la solicitud
+				}
 				return nil, outputError
 			}
 		} else {
-			logs.Info("Error (2) servicio caido")
-			outputError = map[string]interface{}{"Function": "GetUnidad", "Error": err}
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "GetUnidad - request.GetJsonTest(urlUnidad, &unidadAux)",
+				"err":     err,
+				"status":  "502", // Error (2) servicio caido
+			}
 			return nil, outputError
 		}
 	} else {
-		logs.Info("Error (1) Parametro")
-		outputError = map[string]interface{}{"Function": "FuncionalidadMidController:GetUnidad", "Error": "null parameter"}
+		err := fmt.Errorf("unidadId MUST be greater than 0")
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "GetUnidad",
+			"err":     err,
+			"status":  "400", // null parameter
+		}
 		return nil, outputError
 	}
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -175,11 +175,26 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/models.Elemento"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Elemento"
+                            }
                         }
+                    },
+                    "204": {
+                        "description": "Empty response (Due to Act not found or without elements)"
+                    },
+                    "400": {
+                        "description": "Wrong ID (MUST be greater than 0)"
                     },
                     "404": {
                         "description": "not found resource"
+                    },
+                    "500": {
+                        "description": "Internal Error"
+                    },
+                    "502": {
+                        "description": "Error with external API"
                     }
                 }
             }

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -121,9 +121,19 @@ paths:
         "200":
           description: ""
           schema:
-            $ref: '#/definitions/models.Elemento'
+            type: array
+            items:
+              $ref: '#/definitions/models.Elemento'
+        "204":
+          description: Empty response (Due to Act not found or without elements)
+        "400":
+          description: Wrong ID (MUST be greater than 0)
         "404":
           description: not found resource
+        "500":
+          description: Internal Error
+        "502":
+          description: Error with external API
   /acta_recibido/get_soportes_acta/{id}:
     get:
       tags:


### PR DESCRIPTION
Relacionado con udistrital/arka_cliente#430

El endpoint `/acta_recibido/get_elementos_acta/{id}`  "crashea" cuando se le manda un ID de un acta sin elementos o inexistente, porque la consulta al [CRUD de Actas](https://github.com/udistrital/acta_recibido_crud) (endpoint `elemento?query=SoporteActaId.ActaRecibidoId.Id:XXX`) retorna un `[{}]` en tales casos

Ahora se arregló para que retorne un [código de estado HTTP 204](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)

Se deja en estado Draft para colocar un commit adicional para actualizar el swagger asociado a este endpoint (`/acta_recibido/get_elementos_acta/{id}`)