### PR TITLE
Fix/error sin actas

### DIFF
--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -206,8 +206,6 @@ func (c *ActaRecibidoController) GetAllActas() {
 
 	var reqStates []string
 	var WSO2user string
-	var idProveedor int
-	var idContratista int
 
 	if v := c.GetString("states"); v != "" {
 		reqStates = strings.Split(v, ",")
@@ -217,32 +215,6 @@ func (c *ActaRecibidoController) GetAllActas() {
 
 	if v := c.GetString("u"); v != "" {
 		WSO2user = v
-	}
-
-	if v, err := c.GetInt("provId", 0); err == nil {
-		// fmt.Printf("ProveedorID: %d\n", v)
-		idProveedor = v
-	} else {
-		// fmt.Print("Error proveedor: ")
-		// fmt.Println(err)
-		panic(err)
-	}
-
-	if v, err := c.GetInt("contrId", 0); err == nil {
-		// fmt.Printf("ContratistaID: %d\n", v)
-		idContratista = v
-	} else {
-		// fmt.Print("Error contratista: ")
-		// fmt.Println(err)
-		panic(err)
-	}
-
-	if idProveedor < 0 || idContratista < 0 {
-		panic(map[string]interface{}{
-			"funcion": "GetAllActas",
-			"err":     "IDs MUST be positive (or 0 for no filter)",
-			"status":  "400",
-		})
 	}
 
 	if l, err := actaRecibido.GetAllActasRecibidoActivas(reqStates, WSO2user); err == nil {

--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -199,7 +199,7 @@ func (c *ActaRecibidoController) GetAllActas() {
 			if status, ok := localError["status"]; ok {
 				c.Abort(status.(string))
 			} else {
-				c.Abort("400")
+				c.Abort("500") // Unhandled Error!
 			}
 		}
 	}()
@@ -208,13 +208,41 @@ func (c *ActaRecibidoController) GetAllActas() {
 	var WSO2user string
 
 	if v := c.GetString("states"); v != "" {
-		reqStates = strings.Split(v, ",")
+		valido := false
+		states := strings.Split(v, ",")
+		for _, state := range states {
+			state = strings.TrimSpace(state)
+			if state != "" {
+				reqStates = append(reqStates, state)
+				valido = true
+			}
+		}
+
+		if !valido {
+			panic(map[string]interface{}{
+				"funcion": "GetAllActas",
+				"err":     "Bad syntax. Acts MUST be comma separated",
+				"status":  "400",
+			})
+		}
 	}
 	// fmt.Print("ESTADOS SOLICITADOS: ")
 	// fmt.Println(reqStates)
 
 	if v := c.GetString("u"); v != "" {
-		WSO2user = v
+		valido := false
+		user := strings.TrimSpace(v)
+		if user != "" {
+			WSO2user = v
+			valido = true
+		}
+		if !valido {
+			panic(map[string]interface{}{
+				"funcion": "GetAllActas",
+				"err":     "Bad syntax",
+				"status":  "400",
+			})
+		}
 	}
 
 	if l, err := actaRecibido.GetAllActasRecibidoActivas(reqStates, WSO2user); err == nil {

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -65,7 +65,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "/GetAllActasRecibidoActivas",
+				"funcion": "/GetAllActasRecibidoActivas - Unhandled Error!",
 				"err":     err,
 				"status":  "500",
 			}
@@ -107,25 +107,13 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			if data, err := utilsHelper.ConvertirInterfaceMap(historicos["ActaRecibidoId"]); err == nil {
 				data_ = data
 			} else {
-				logs.Error(err)
-				outputError = map[string]interface{}{
-					"funcion": "/GetAllActasRecibidoActivas",
-					"err":     err,
-					"status":  "500",
-				}
-				return nil, outputError
+				return nil, err
 			}
 
 			if data, err := utilsHelper.ConvertirInterfaceMap(historicos["EstadoActaId"]); err == nil {
 				data2_ = data
 			} else {
-				logs.Error(err)
-				outputError = map[string]interface{}{
-					"funcion": "/GetAllActasRecibidoActivas",
-					"err":     err,
-					"status":  "500",
-				}
-				return nil, outputError
+				return nil, err
 			}
 
 			// findAndAddTercero trae la información de un tercero y la agrega
@@ -291,20 +279,11 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 
 		// TODO: Manejar concurrencia en las peticiones a otras APIS
 		// Referencia: https://www.golang-book.com/books/intro/10
-		// TODO: Quitar los parámetros de ID de Proveedor y Contratista
-		// de la siguiente función, una vez sea uniforme el espacio de
-		// usuarios
 		if usrWSO2 != "" {
 			if actas, err := filtrarActasSegunRoles(historicoActa, usrWSO2); err == nil {
 				historicoActa = actas
 			} else {
-				logs.Error(err)
-				outputError = map[string]interface{}{
-					"funcion": "/GetAllActasRecibidoActivas",
-					"err":     err,
-					"status":  "502",
-				}
-				return nil, outputError
+				return nil, err
 			}
 		}
 
@@ -313,9 +292,9 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	} else {
 		logs.Error(err)
 		outputError = map[string]interface{}{
-			"funcion": "/GetAllActasRecibidoActivas",
+			"funcion": "/GetAllActasRecibidoActivas - request.GetJsonTest(url, &Historico)",
 			"err":     err,
-			"status":  "502",
+			"status":  "502", // (2) error servicio caido
 		}
 		return nil, outputError
 	}

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -128,34 +128,33 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				return nil, outputError
 			}
 
-			if Terceros == nil {
+			// findAndAddTercero trae la información de un tercero y la agrega
+			// al buffer de terceros
+			findAndAddTercero := func() map[string]interface{} {
 				if Tercero, err := tercerosHelper.GetNombreTerceroById2(fmt.Sprintf("%v", data_["RevisorId"])); err == nil {
 					Tercero_ = Tercero
 					Terceros = append(Terceros, Tercero)
+					return nil
 				} else {
 					logs.Error(err)
-					outputError = map[string]interface{}{
-						"funcion": "/GetAllActasRecibidoActivas",
+					return map[string]interface{}{
+						"funcion": "/GetAllActasRecibidoActivas/findAndAddTercero",
 						"err":     err,
 						"status":  "502",
 					}
-					return nil, outputError
+				}
+			}
+
+			if Terceros == nil {
+				if err := findAndAddTercero(); err != nil {
+					return nil, err
 				}
 			} else {
 				if keys := len(Terceros[0]); keys != 0 {
 					if Tercero, err := utilsHelper.ArrayFind(Terceros, "Id", fmt.Sprintf("%v", data_["RevisorId"])); err == nil {
 						if keys := len(Tercero); keys == 0 {
-							if Tercero, err := tercerosHelper.GetNombreTerceroById2(fmt.Sprintf("%v", data_["RevisorId"])); err == nil {
-								Tercero_ = Tercero
-								Terceros = append(Terceros, Tercero)
-							} else {
-								logs.Error(err)
-								outputError = map[string]interface{}{
-									"funcion": "/GetAllActasRecibidoActivas",
-									"err":     err,
-									"status":  "502",
-								}
-								return nil, outputError
+							if err := findAndAddTercero(); err != nil {
+								return nil, err
 							}
 						} else {
 							Tercero_ = Tercero
@@ -170,17 +169,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 						return nil, outputError
 					}
 				} else {
-					if Tercero, err := tercerosHelper.GetNombreTerceroById2(fmt.Sprintf("%v", data_["RevisorId"])); err == nil {
-						Tercero_ = Tercero
-						Terceros = append(Terceros, Tercero)
-					} else {
-						logs.Error(err)
-						outputError = map[string]interface{}{
-							"funcion": "/GetAllActasRecibidoActivas",
-							"err":     err,
-							"status":  "502",
-						}
-						return nil, outputError
+					if err := findAndAddTercero(); err != nil {
+						return nil, err
 					}
 				}
 			}

--- a/helpers/utilsHelper/utilsHelper.helper.go
+++ b/helpers/utilsHelper/utilsHelper.helper.go
@@ -13,7 +13,7 @@ func ConvertirInterfaceMap(Objeto interface{}) (Salida map[string]interface{}, o
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "/ConvertirInterfaceMap",
+				"funcion": "/ConvertirInterfaceMap - Unhandled Error!",
 				"err":     err,
 				"status":  "500",
 			}
@@ -25,7 +25,7 @@ func ConvertirInterfaceMap(Objeto interface{}) (Salida map[string]interface{}, o
 		if err2 := json.Unmarshal(jsonString, &Salida); err2 != nil {
 			logs.Error(err)
 			outputError = map[string]interface{}{
-				"funcion": "/ConvertirInterfaceMap",
+				"funcion": "/ConvertirInterfaceMap - json.Unmarshal(jsonString, &Salida)",
 				"err":     err,
 				"status":  "500",
 			}
@@ -34,7 +34,7 @@ func ConvertirInterfaceMap(Objeto interface{}) (Salida map[string]interface{}, o
 	} else {
 		logs.Error(err)
 		outputError = map[string]interface{}{
-			"funcion": "/ConvertirInterfaceMap",
+			"funcion": "/ConvertirInterfaceMap - json.Marshal(Objeto)",
 			"err":     err,
 			"status":  "500",
 		}


### PR DESCRIPTION
Si no hay actas registradas, el MID "crashea" dado que el endpoint `historico?query=...` del CRUD de Actas retorna `[{}]` en dicho caso, y el MID, al ver que hay un objeto va a intentar iterarlo y por consiguiente, iterar propiedades que no existen