### PR TITLE
Refactorizada consulta de actas

### DIFF
--- a/controllers/acta_recibido.go
+++ b/controllers/acta_recibido.go
@@ -75,7 +75,7 @@ func (c *ActaRecibidoController) GetAll() {
 // GetActasByTipo ...
 // @Title GetActasRecibidoTipo
 // @Description Devuelve las todas las actas de recibido
-// @Param	id		path 	string	true		"id del acta"
+// @Param	tipo		path 	string	true		"Estado del acta"
 // @Success 200 {object} models.Acta_recibido
 // @Failure 403
 // @router /get_actas_recibido_tipo/:tipo [get]
@@ -85,18 +85,29 @@ func (c *ActaRecibidoController) GetActasByTipo() {
 		if err := recover(); err != nil {
 			logs.Error(err)
 			localError := err.(map[string]interface{})
-			c.Data["mesaage"] = (beego.AppConfig.String("appname") + "/" + "GetActasByTipo" + "/" + (localError["funcion"]).(string))
+			c.Data["message"] = (beego.AppConfig.String("appname") + "/" + "ActaRecibidoController" + "/" + (localError["funcion"]).(string))
 			c.Data["data"] = (localError["err"])
 			if status, ok := localError["status"]; ok {
 				c.Abort(status.(string))
 			} else {
-				c.Abort("404")
+				c.Abort("500") // Error no manejado!
 			}
 		}
 	}()
 
-	tipoStr := c.Ctx.Input.Param(":tipo")
-	tipo, _ := strconv.Atoi(tipoStr)
+	var tipo int
+
+	if v, err := c.GetInt(":tipo"); err == nil {
+		tipo = v
+	} else {
+		err := fmt.Errorf("{tipo} must be an Integer")
+		logs.Error(err)
+		panic(map[string]interface{}{
+			"funcion": "GetActasByTipo",
+			"err":     err,
+			"status":  "400",
+		})
+	}
 
 	if v, err := actaRecibido.GetActasRecibidoTipo(tipo); err == nil {
 		c.Data["json"] = v

--- a/helpers/actaRecibido/actaRecibd.helper.go
+++ b/helpers/actaRecibido/actaRecibd.helper.go
@@ -1,6 +1,7 @@
 package actaRecibido
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/astaxie/beego"
@@ -17,9 +18,9 @@ func GetActasRecibidoTipo(tipoActa int) (actasRecibido []models.ActaRecibidoUbic
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "/GetActasRecibidoTipo",
+				"funcion": "/GetActasRecibidoTipo - Unhandled Error!",
 				"err":     err,
-				"status":  "502",
+				"status":  "500",
 			}
 			panic(outputError)
 		}
@@ -31,59 +32,66 @@ func GetActasRecibidoTipo(tipoActa int) (actasRecibido []models.ActaRecibidoUbic
 	)
 	if tipoActa != 0 { // (1) error parametro
 		urlcrud = "http://" + beego.AppConfig.String("actaRecibidoService") + "historico_acta?query=EstadoActaId.Id:" + strconv.Itoa(tipoActa) + ",Activo:True&limit=-1"
-		logs.Debug(urlcrud)
+		// logs.Debug(urlcrud)
 		if response, err := request.GetJsonTest(urlcrud, &historicoActa); err == nil && response.StatusCode == 200 { // (2) error servicio caido
-			logs.Debug(historicoActa[0].EstadoActaId)
+			// logs.Debug(historicoActa[0].EstadoActaId)
+			// logs.Debug("Estado:", tipoActa, "- Actas:", len(historicoActa), "- Id_acta[0]:", historicoActa[0].Id)
 
 			if len(historicoActa) == 0 || historicoActa[0].Id == 0 {
-				logs.Error(err)
-				outputError = map[string]interface{}{
-					"funcion": "/GetActasRecibidoTipo",
-					"err":     err,
-					"status":  "200",
-				}
-				return nil, outputError
+				return nil, nil
 			}
+			// logs.Debug(historicoActa, "- len:", len(historicoActa))
 
-			if response.StatusCode == 200 { // (3) error estado de la solicitud
-				for _, acta := range historicoActa {
-					// UBICACION
-					ubicacion, err := ubicacionHelper.GetUbicacion(acta.ActaRecibidoId.UbicacionId)
+			for _, acta := range historicoActa {
+				logs.Debug("holiActa", acta)
+				// UBICACION
+				var ubicacion *models.EspacioFisico
 
-					if err != nil {
-						panic(err)
+				if id := acta.ActaRecibidoId.UbicacionId; id > 0 {
+					if ubicaciones, err := ubicacionHelper.GetUbicacion(id); err == nil {
+						ubicacion = ubicaciones[0]
+					} else {
+						return nil, err
 					}
-
-					logs.Debug(ubicacion)
-
-					actaRecibidoAux := models.ActaRecibidoUbicacion{
-						Id:                acta.ActaRecibidoId.Id,
-						RevisorId:         acta.ActaRecibidoId.RevisorId,
-						FechaCreacion:     acta.ActaRecibidoId.FechaCreacion,
-						FechaModificacion: acta.ActaRecibidoId.FechaModificacion,
-						FechaVistoBueno:   acta.ActaRecibidoId.FechaVistoBueno,
-						Observaciones:     acta.ActaRecibidoId.Observaciones,
-						Activo:            acta.ActaRecibidoId.Activo,
-						EstadoActaId:      acta.EstadoActaId,
-						UbicacionId:       ubicacion[0],
-					}
-
-					actasRecibido = append(actasRecibido, actaRecibidoAux)
 				}
-				return actasRecibido, nil
-			} else {
-				logs.Info("Error (3) estado de la solicitud")
-				outputError = map[string]interface{}{"Function": "GetActasRecibidoTipo:GetActasRecibidoTipo", "Error": response.Status}
-				return nil, outputError
+
+				// logs.Debug(ubicacion)
+
+				actaRecibidoAux := models.ActaRecibidoUbicacion{
+					Id:                acta.ActaRecibidoId.Id,
+					RevisorId:         acta.ActaRecibidoId.RevisorId,
+					FechaCreacion:     acta.ActaRecibidoId.FechaCreacion,
+					FechaModificacion: acta.ActaRecibidoId.FechaModificacion,
+					FechaVistoBueno:   acta.ActaRecibidoId.FechaVistoBueno,
+					Observaciones:     acta.ActaRecibidoId.Observaciones,
+					Activo:            acta.ActaRecibidoId.Activo,
+					EstadoActaId:      acta.EstadoActaId,
+					UbicacionId:       ubicacion,
+				}
+
+				actasRecibido = append(actasRecibido, actaRecibidoAux)
 			}
+			return actasRecibido, nil
 		} else {
-			logs.Info("Error (2) servicio caido")
-			outputError = map[string]interface{}{"Function": "GetActasRecibidoTipo", "Error": err}
+			if err == nil {
+				err = fmt.Errorf("Error (3) estado de la solicitud: %s", response.Status)
+			}
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "/GetActasRecibidoTipo",
+				"err":     err,
+				"status:": "502",
+			}
 			return nil, outputError
 		}
 	} else {
-		logs.Info("Error (1) Parametro")
-		outputError = map[string]interface{}{"Function": "FuncionalidadMidController:getUserAgora", "Error": "null parameter"}
+		err := fmt.Errorf("Error (1) Parametro")
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "/GetActasRecibidoTipo",
+			"err":     err,
+			"status":  "400",
+		}
 		return nil, outputError
 	}
 

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -54,7 +54,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	// fmt.Println(states)
 
 	url := "http://" + beego.AppConfig.String("actaRecibidoService") + "historico_acta?limit=-1&query=Activo:true"
-	fmt.Println(url)
+	// fmt.Println(url)
 	// url += ",EstadoActaId__Id:3"
 	// TODO: Por rendimiento, TODO lo relacionado a ...
 	// - buscar el historico_acta mas reciente
@@ -120,7 +120,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				if Tercero, err := tercerosHelper.GetNombreTerceroById(idStr); err == nil {
 					if keys := len(Tercero); keys != 0 {
 						Terceros[TerceroId] = Tercero
-						logs.Debug("len(Terceros)", len(Terceros))
 					}
 					return Tercero, nil
 				} else {

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -104,6 +104,11 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			// findAndAddTercero trae la información de un tercero y la agrega
 			// al buffer de terceros
 			findAndAddTercero := func(TerceroId int) (map[string]interface{}, map[string]interface{}) {
+
+				if TerceroId == 0 {
+					return nil, nil
+				}
+
 				idStr := fmt.Sprint(TerceroId)
 
 				if Tercero, ok := Terceros[TerceroId]; ok {
@@ -138,6 +143,11 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			// findAndAddUbicacion trae la información de una ubicación y la agrega
 			// al buffer de ubicaciones
 			findAndAddUbicacion := func(UbicacionId int) (map[string]interface{}, map[string]interface{}) {
+
+				if UbicacionId == 0 {
+					return nil, nil
+				}
+
 				idStr := fmt.Sprint(UbicacionId)
 
 				if ubicacion, ok := Ubicaciones[UbicacionId]; ok {

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -85,7 +85,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			var editor map[string]interface{}
 			var preUbicacion map[string]interface{}
 			// var nombreAsignado string
-			var asignado *models.Proveedor
+			var oldAsignado *models.Proveedor
+			var asignado map[string]interface{}
 
 			preUbicacion = nil
 
@@ -215,6 +216,9 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 
 			var tmpAsignadoId = int(acta["PersonaAsignada"].(float64))
 			if v, err := findAndAddProveedor(tmpAsignadoId); err == nil {
+				oldAsignado = v
+			}
+			if v, err := findAndAddTercero(tmpAsignadoId); err == nil {
 				asignado = v
 			}
 
@@ -245,7 +249,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				"Id":                acta["Id"],
 				"Observaciones":     acta["Observaciones"],
 				"RevisorId":         editor["NombreCompleto"],
-				"PersonaAsignada":   asignado.NomProveedor,
+				"oldAsignada":       oldAsignado.NomProveedor,
+				"PersonaAsignada":   asignado["NombreCompleto"],
 				"PersonaAsignadaId": tmpAsignadoId,
 				"Estado":            estado["Nombre"],
 			}

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -138,41 +138,38 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				}
 			}
 
-			if Ubicaciones == nil {
+			// findAndAddUbicacion trae la información de una ubicación y la agrega
+			// al buffer de ubicaciones
+			findAndAddUbicacion := func() map[string]interface{} {
 				if ubicacion, err := ubicacionHelper.GetAsignacionSedeDependencia(fmt.Sprintf("%v", acta["UbicacionId"])); err == nil {
 					// fmt.Println(ubicacion)
 					if keys := len(ubicacion); keys != 0 {
 						preUbicacion = ubicacion
 						Ubicaciones = append(Ubicaciones, ubicacion)
 					}
+					return nil
 
 				} else {
 					logs.Error(err)
 					outputError = map[string]interface{}{
-						"funcion": "/GetAllActasRecibidoActivas",
+						"funcion": "/GetAllActasRecibidoActivas/findAndAddUbicacion",
 						"err":     err,
 						"status":  "502",
 					}
-					return nil, outputError
+					return outputError
+				}
+			}
+
+			if Ubicaciones == nil {
+				if err := findAndAddUbicacion(); err != nil {
+					return nil, err
 				}
 			} else {
 				if keys := len(Ubicaciones[0]); keys != 0 {
 					if ubicacion, err := utilsHelper.ArrayFind(Ubicaciones, "Id", fmt.Sprintf("%v", acta["UbicacionId"])); err == nil {
 						if keys := len(ubicacion); keys == 0 {
-							if ubicacion, err := ubicacionHelper.GetAsignacionSedeDependencia(fmt.Sprintf("%v", acta["UbicacionId"])); err == nil {
-								// fmt.Println(ubicacion)
-								if keys := len(ubicacion); keys != 0 {
-									preUbicacion = ubicacion
-									Ubicaciones = append(Ubicaciones, ubicacion)
-								}
-							} else {
-								logs.Error(err)
-								outputError = map[string]interface{}{
-									"funcion": "/GetAllActasRecibidoActivas",
-									"err":     err,
-									"status":  "502",
-								}
-								return nil, outputError
+							if err := findAndAddUbicacion(); err != nil {
+								return nil, err
 							}
 						} else {
 							preUbicacion = ubicacion
@@ -187,20 +184,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 						return nil, outputError
 					}
 				} else {
-					if ubicacion, err := ubicacionHelper.GetAsignacionSedeDependencia(fmt.Sprintf("%v", acta["UbicacionId"])); err == nil {
-						// fmt.Println(ubicacion)
-						if keys := len(ubicacion); keys != 0 {
-							preUbicacion = ubicacion
-							Ubicaciones = append(Ubicaciones, ubicacion)
-						}
-					} else {
-						logs.Error(err)
-						outputError = map[string]interface{}{
-							"funcion": "/GetAllActasRecibidoActivas",
-							"err":     err,
-							"status":  "502",
-						}
-						return nil, outputError
+					if err := findAndAddUbicacion(); err != nil {
+						return nil, err
 					}
 				}
 			}

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -50,6 +50,104 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	evUbicaciones := 0
 	evProveedores := 0
 
+	// findAndAddTercero trae la información de un tercero y la agrega
+	// al buffer de terceros
+	findAndAddTercero := func(TerceroId int) (map[string]interface{}, map[string]interface{}) {
+
+		if TerceroId == 0 {
+			return nil, nil
+		}
+
+		idStr := fmt.Sprint(TerceroId)
+
+		if Tercero, ok := Terceros[TerceroId]; ok {
+			evTerceros++
+			return Tercero, nil
+		}
+
+		consultasTerceros++
+		if Tercero, err := tercerosHelper.GetNombreTerceroById(idStr); err == nil {
+			if keys := len(Tercero); keys != 0 {
+				Terceros[TerceroId] = Tercero
+			}
+			return Tercero, nil
+		} else {
+			logs.Error(err)
+			return nil, map[string]interface{}{
+				"funcion": "/GetAllActasRecibidoActivas/findAndAddTercero",
+				"err":     err,
+				"status":  "502",
+			}
+		}
+	}
+
+	// findAndAddUbicacion trae la información de una ubicación y la agrega
+	// al buffer de ubicaciones
+	findAndAddUbicacion := func(UbicacionId int) (map[string]interface{}, map[string]interface{}) {
+
+		if UbicacionId == 0 {
+			return nil, nil
+		}
+
+		idStr := fmt.Sprint(UbicacionId)
+
+		if ubicacion, ok := Ubicaciones[UbicacionId]; ok {
+			evUbicaciones++
+			return ubicacion, nil
+		}
+
+		consultasUbicaciones++
+		if ubicacion, err := ubicacionHelper.GetAsignacionSedeDependencia(idStr); err == nil {
+			if keys := len(ubicacion); keys != 0 {
+				Ubicaciones[UbicacionId] = ubicacion
+			}
+			return ubicacion, nil
+		} else {
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "/GetAllActasRecibidoActivas/findAndAddUbicacion",
+				"err":     err,
+				"status":  "502",
+			}
+			return nil, outputError
+		}
+	}
+
+	// findAndAddUbicacion trae la información de un proveedor y la agrega
+	// al buffer de proveedores
+	// (Nota: Evitar usar, se va a usar terceros en vez de Agora)
+	findAndAddProveedor := func(ProveedorId int) (*models.Proveedor, map[string]interface{}) {
+
+		var vacio models.Proveedor
+		if ProveedorId == 0 {
+			return &vacio, nil
+		}
+
+		if proveedor, ok := Proveedores[ProveedorId]; ok {
+			evProveedores++
+			return proveedor, nil
+		}
+
+		// if ProveedorId > 0 {
+		consultasProveedores++
+		if provs, err := proveedorHelper.GetProveedorById(ProveedorId); err == nil {
+			if len(provs) == 1 && provs[0].Id > 0 {
+				proveedor := provs[0]
+				Proveedores[ProveedorId] = proveedor
+				return proveedor, nil
+			}
+			if len(provs) > 1 {
+				logs.Warn("Proveedor", ProveedorId, "tiene más de un resultado")
+			}
+		} else {
+			return nil, err
+		}
+
+		// }
+
+		return &vacio, nil
+	}
+
 	// fmt.Print("Estados Solicitados: ")
 	// fmt.Println(states)
 
@@ -102,37 +200,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				return nil, err
 			}
 
-			// findAndAddTercero trae la información de un tercero y la agrega
-			// al buffer de terceros
-			findAndAddTercero := func(TerceroId int) (map[string]interface{}, map[string]interface{}) {
-
-				if TerceroId == 0 {
-					return nil, nil
-				}
-
-				idStr := fmt.Sprint(TerceroId)
-
-				if Tercero, ok := Terceros[TerceroId]; ok {
-					evTerceros++
-					return Tercero, nil
-				}
-
-				consultasTerceros++
-				if Tercero, err := tercerosHelper.GetNombreTerceroById(idStr); err == nil {
-					if keys := len(Tercero); keys != 0 {
-						Terceros[TerceroId] = Tercero
-					}
-					return Tercero, nil
-				} else {
-					logs.Error(err)
-					return nil, map[string]interface{}{
-						"funcion": "/GetAllActasRecibidoActivas/findAndAddTercero",
-						"err":     err,
-						"status":  "502",
-					}
-				}
-			}
-
 			idRev := int(acta["RevisorId"].(float64))
 			if v, err := findAndAddTercero(idRev); err == nil {
 				editor = v
@@ -140,78 +207,11 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				return nil, err
 			}
 
-			// findAndAddUbicacion trae la información de una ubicación y la agrega
-			// al buffer de ubicaciones
-			findAndAddUbicacion := func(UbicacionId int) (map[string]interface{}, map[string]interface{}) {
-
-				if UbicacionId == 0 {
-					return nil, nil
-				}
-
-				idStr := fmt.Sprint(UbicacionId)
-
-				if ubicacion, ok := Ubicaciones[UbicacionId]; ok {
-					evUbicaciones++
-					return ubicacion, nil
-				}
-
-				consultasUbicaciones++
-				if ubicacion, err := ubicacionHelper.GetAsignacionSedeDependencia(idStr); err == nil {
-					if keys := len(ubicacion); keys != 0 {
-						Ubicaciones[UbicacionId] = ubicacion
-					}
-					return ubicacion, nil
-				} else {
-					logs.Error(err)
-					outputError = map[string]interface{}{
-						"funcion": "/GetAllActasRecibidoActivas/findAndAddUbicacion",
-						"err":     err,
-						"status":  "502",
-					}
-					return nil, outputError
-				}
-			}
-
 			idUb := int(acta["UbicacionId"].(float64))
 			if v, err := findAndAddUbicacion(idUb); err == nil {
 				preUbicacion = v
 			} else {
 				return nil, err
-			}
-
-			// findAndAddUbicacion trae la información de un proveedor y la agrega
-			// al buffer de proveedores
-			// (Nota: Evitar usar, se va a usar terceros en vez de Agora)
-			findAndAddProveedor := func(ProveedorId int) (*models.Proveedor, map[string]interface{}) {
-
-				var vacio models.Proveedor
-				if ProveedorId == 0 {
-					return &vacio, nil
-				}
-
-				if proveedor, ok := Proveedores[ProveedorId]; ok {
-					evProveedores++
-					return proveedor, nil
-				}
-
-				// if ProveedorId > 0 {
-				consultasProveedores++
-				if provs, err := proveedorHelper.GetProveedorById(ProveedorId); err == nil {
-					if len(provs) == 1 && provs[0].Id > 0 {
-						proveedor := provs[0]
-						Proveedores[ProveedorId] = proveedor
-						return proveedor, nil
-					}
-					if len(provs) > 1 {
-						logs.Warn("Proveedor", ProveedorId, "tiene más de un resultado")
-					}
-				} else {
-					return nil, err
-				}
-
-				// }
-
-				return &vacio, nil
 			}
 
 			var tmpAsignadoId = int(acta["PersonaAsignada"].(float64))

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -130,7 +130,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			return proveedor, nil
 		}
 
-		// if ProveedorId > 0 {
 		consultasProveedores++
 		if provs, err := proveedorHelper.GetProveedorById(ProveedorId); err == nil {
 			if len(provs) == 1 && provs[0].Id > 0 {
@@ -144,8 +143,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 		} else {
 			return nil, err
 		}
-
-		// }
 
 		return &vacio, nil
 	}
@@ -281,9 +278,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	// PARTE 2: Traer los tipos de actas identificados
 	// (con base a la estrategia definida anteriormente)
 
-	url := "http://" + beego.AppConfig.String("actaRecibidoService") + "historico_acta?limit=-1&query=Activo:true"
-	// fmt.Println(url)
-	// url += ",EstadoActaId__Id:3"
 	// TODO: Por rendimiento, TODO lo relacionado a ...
 	// - buscar el historico_acta mas reciente
 	// - Filtrar por estados
@@ -383,23 +377,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 
 	}
 
-	return Historico, nil
-
-	if resp, err := request.GetJsonTest(url, &Historico); err == nil && resp.StatusCode == 200 { // (2) error servicio caido
-
-		// fmt.Print("historicos:")
-		// fmt.Println(len(Historico))
-
-		if len(Historico) == 0 || len(Historico[0]) == 0 {
-			err := errors.New("There's currently no act records")
-			logs.Warn(err)
-			outputError = map[string]interface{}{
-				"funcion": "/GetAllActasRecibidoActivas",
-				"err":     err,
-				"status":  "200", // TODO: Debería ser un 204 pero el cliente (Angular) se ofende... (hay que hacer varios ajustes)
-			}
-			return nil, outputError
-		}
+	// PARTE 3: Completar data faltante
+	if len(Historico) > 0 {
 
 		for _, historicos := range Historico {
 
@@ -408,8 +387,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			var ubicacionData map[string]interface{}
 			var editor map[string]interface{}
 			var preUbicacion map[string]interface{}
-			// var nombreAsignado string
-			var oldAsignado *models.Proveedor
+			var oldAsignado *models.Proveedor // "old": de proveedores, se va a eliminar
 			var asignado map[string]interface{}
 
 			preUbicacion = nil
@@ -492,23 +470,8 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 		logs.Info(len(historicoActa), "actas")
 		return historicoActa, nil
 
-	} else if err != nil {
-		logs.Error(err)
-		outputError = map[string]interface{}{
-			"funcion": "/GetAllActasRecibidoActivas - request.GetJsonTest(url, &Historico)",
-			"err":     err,
-			"status":  "502", // (2) error servicio caido
-		}
-		return nil, outputError
 	} else {
-		err := fmt.Errorf("Undesired Status Code: %d", resp.StatusCode)
-		logs.Error(err)
-		outputError = map[string]interface{}{
-			"funcion": "/GetAllActasRecibidoActivas - request.GetJsonTest(url, &Historico)",
-			"err":     err,
-			"status":  "502", // (2) error servicio caido
-		}
-		return nil, outputError
+		return nil, nil
 	}
 }
 

--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -118,6 +118,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	// findAndAddUbicacion trae la información de un proveedor y la agrega
 	// al buffer de proveedores
 	// (Nota: Evitar usar, se va a usar terceros en vez de Agora)
+
 	findAndAddProveedor := func(ProveedorId int) (*models.Proveedor, map[string]interface{}) {
 
 		var vacio models.Proveedor
@@ -146,6 +147,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 
 		return &vacio, nil
 	}
+	findAndAddProveedor(0)
 
 	// PARTE 1 - Identificar los tipos de actas que hay que traer
 	// (y así definir la estrategia para traer las actas)
@@ -426,7 +428,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			var ubicacionData map[string]interface{}
 			var editor map[string]interface{}
 			var preUbicacion map[string]interface{}
-			var oldAsignado *models.Proveedor // "old": de proveedores, se va a eliminar
+			// var oldAsignado *models.Proveedor // "old": de proveedores, se va a eliminar
 			var asignado map[string]interface{}
 
 			preUbicacion = nil
@@ -458,9 +460,9 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 			}
 
 			var tmpAsignadoId = int(acta["PersonaAsignada"].(float64))
-			if v, err := findAndAddProveedor(tmpAsignadoId); err == nil {
-				oldAsignado = v
-			}
+			// if v, err := findAndAddProveedor(tmpAsignadoId); err == nil {
+			// 	oldAsignado = v
+			// }
 			if v, err := findAndAddTercero(tmpAsignadoId); err == nil {
 				asignado = v
 			}
@@ -492,10 +494,10 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				"Id":                acta["Id"],
 				"Observaciones":     acta["Observaciones"],
 				"RevisorId":         editor["NombreCompleto"],
-				"oldAsignada":       oldAsignado.NomProveedor,
-				"PersonaAsignada":   asignado["NombreCompleto"],
-				"PersonaAsignadaId": tmpAsignadoId,
-				"Estado":            estado["Nombre"],
+				// "oldAsignada":       oldAsignado.NomProveedor,
+				"PersonaAsignada": asignado["NombreCompleto"],
+				// "PersonaAsignadaId": tmpAsignadoId,
+				"Estado": estado["Nombre"],
 			}
 			// fmt.Println("Es esto")
 			// fmt.Println(Acta)

--- a/helpers/actaRecibido/filtroActas.go
+++ b/helpers/actaRecibido/filtroActas.go
@@ -16,13 +16,19 @@ import (
 // Llaves: estados válidos de Actas
 // Valores: mapeables desde models.RolesArka
 var reglasVerTodas = map[string][]string{
-	"Registrada":         []string{models.RolesArka["Admin"], models.RolesArka["Revisor"], models.RolesArka["Secretaria"]},
-	"En Elaboracion":     []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
-	"En Modificacion":    []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
-	"En verificacion":    []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
-	"Aceptada":           []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
-	"Asociada a Entrada": []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
-	"Anulada":            []string{models.RolesArka["Admin"], models.RolesArka["Revisor"]},
+	"Registrada":         {models.RolesArka["Secretaria"]},
+	"En Elaboracion":     {},
+	"En Modificacion":    {},
+	"En verificacion":    {},
+	"Aceptada":           {},
+	"Asociada a Entrada": {},
+	"Anulada":            {},
+}
+
+// Arreglo de roles que pueden ver actas en cualquier estado
+var verCualquierEstado = []string{
+	models.RolesArka["Admin"],
+	models.RolesArka["Revisor"],
 }
 
 func filtrarActasSegunRoles(actas []map[string]interface{}, usuarioWSO2 string,

--- a/helpers/actaRecibido/filtroActas.go
+++ b/helpers/actaRecibido/filtroActas.go
@@ -68,11 +68,11 @@ func filtrarActasSegunRoles(actas []map[string]interface{}, usuarioWSO2 string,
 		contratista := 0
 
 		if soloAsignadas {
-			if proveedores, err2 := proveedorHelper.GetProveedorByDoc(data.Documento); err2 == nil && len(proveedores) > 0 {
+			if prov, err := proveedorHelper.GetProveedorByDoc(data.Documento); err == nil {
 				// for k, prov := range proveedores {
 				// 	fmt.Printf("Prov: %v - Data: %#v\n", k, prov)
 				// }
-				idProveedor := proveedores[0].Id
+				idProveedor := prov.Id
 				for _, role := range data.Role {
 					if role == models.RolesArka["Proveedor"] {
 						proveedor = idProveedor
@@ -85,22 +85,8 @@ func filtrarActasSegunRoles(actas []map[string]interface{}, usuarioWSO2 string,
 						break
 					}
 				}
-			} else if err2 != nil {
-				logs.Error(err2)
-				outputError = map[string]interface{}{
-					"funcion": "/filtrarActasSegunRoles",
-					"err":     err2,
-					"status":  "502",
-				}
-				return nil, outputError
 			} else {
-				outputError = map[string]interface{}{
-					"funcion": "/filtrarActasSegunRoles",
-					"err":     "No se encuentra un proveedor con el documento especificado",
-					"status":  "404",
-				}
-				logs.Error(outputError)
-				return nil, outputError
+				return nil, err
 			}
 		}
 		// fmt.Printf("Solo Actas Asignadas: %t\n", soloAsignadas)

--- a/helpers/tercerosHelper/tercero.helper.go
+++ b/helpers/tercerosHelper/tercero.helper.go
@@ -109,3 +109,16 @@ func GetTerceroByUsuarioWSO2(usuario string) (tercero map[string]interface{}, ou
 
 	return tercero, nil
 }
+
+func GetTerceroByDoc(doc string) (tercero *models.DatosIdentificacion, outputError map[string]interface{}) {
+	urltercero := "http://" + beego.AppConfig.String("tercerosService") + "datos_identificacion/?query=Activo:true"
+	urltercero += "Numero:" + doc
+	var terceros []*models.DatosIdentificacion
+
+	if resp, err := request.GetJsonTest(urltercero, &terceros); err == nil && resp.StatusCode == 200 {
+		return terceros[0], nil
+	}
+
+	var vacio models.DatosIdentificacion
+	return &vacio, nil
+}

--- a/helpers/tercerosHelper/tercero.helper.go
+++ b/helpers/tercerosHelper/tercero.helper.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/logs"
 
+	"github.com/udistrital/arka_mid/models"
 	"github.com/udistrital/utils_oas/request"
 )
 
@@ -40,4 +42,70 @@ func GetNombreTerceroById(idTercero string) (tercero map[string]interface{}, err
 
 	return
 
+}
+
+// GetTerceroByUsuarioWSO2 trae la información de un tercero a partir de su UsuarioWSO2
+func GetTerceroByUsuarioWSO2(usuario string) (tercero map[string]interface{}, outputError map[string]interface{}) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			outputError = map[string]interface{}{
+				"funcion": "GetTerceroByUsuarioWSO2 - Unhandled Error!",
+				"err":     err,
+				"status":  "500",
+			}
+			panic(outputError)
+		}
+	}()
+
+	var terceros []*models.Tercero
+	urltercero := "http://" + beego.AppConfig.String("tercerosService") + "tercero"
+	urltercero += "?fields=Id,NombreCompleto,TipoContribuyenteId"
+	urltercero += "&query=Activo:true,UsuarioWSO2:" + usuario
+	// logs.Info(urltercero)
+	if resp, err := request.GetJsonTest(urltercero, &terceros); err == nil && resp.StatusCode == 200 {
+		if len(terceros) == 1 && terceros[0].TipoContribuyenteId != nil {
+			data := terceros[0]
+			tercero = map[string]interface{}{
+				"Id":             data.Id,
+				"Numero":         "",
+				"NombreCompleto": data.NombreCompleto,
+			}
+		} else if len(terceros) == 0 || terceros[0].TipoContribuyenteId == nil {
+			err := fmt.Errorf("El usuario '%s' aún no está asignado a un registro en Terceros", usuario)
+			outputError = map[string]interface{}{
+				"funcion": "GetTerceroByUsuarioWSO2 - len(datosTerceros) == 1 && datosTerceros[0].TerceroId != nil",
+				"err":     err,
+				"status":  "404",
+			}
+			return nil, outputError
+		} else { // len(terceros) > 1
+			q := len(terceros)
+			s := ""
+			if q >= 10 {
+				s = " - o más"
+			}
+			err := fmt.Errorf("El usuario '%s' tiene más de un registro en Terceros (%d registros%s)", usuario, q, s)
+			logs.Warn(err)
+			outputError = map[string]interface{}{
+				"funcion": "GetTerceroByUsuarioWSO2 - len(datosTerceros) == 1 && datosTerceros[0].TerceroId != nil",
+				"err":     err,
+				"status":  "409",
+			}
+			return nil, outputError
+		}
+	} else {
+		if err == nil {
+			err = fmt.Errorf("Undesired Status Code: %d", resp.StatusCode)
+		}
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "GetTerceroByUsuarioWSO2 - request.GetJsonTest(urltercero, &datosTerceros)",
+			"err":     err,
+			"status":  "502",
+		}
+		return nil, outputError
+	}
+
+	return tercero, nil
 }

--- a/helpers/tercerosHelper/tercero.helper.go
+++ b/helpers/tercerosHelper/tercero.helper.go
@@ -21,7 +21,7 @@ func GetNombreTerceroById(idTercero string) (tercero map[string]interface{}, err
 				if len(element) == 0 {
 					return nil, errors.New("No se encontro registro")
 				} else {
-					fmt.Println("encargado: ", element)
+					// fmt.Println("encargado: ", element)
 					return map[string]interface{}{
 						"Id":             element["TerceroId"].(map[string]interface{})["Id"],
 						"Numero":         element["Numero"],

--- a/helpers/utilsHelper/utilsHelper.helper.go
+++ b/helpers/utilsHelper/utilsHelper.helper.go
@@ -90,3 +90,23 @@ func ArrayFind(Objeto__ []map[string]interface{}, campo string, valor string) (B
 
 	return Busqueda_, nil
 }
+
+// KeysValuesMap descompone un mapeo en dos arreglos con sus claves y valores
+func KeysValuesMap(m map[interface{}]interface{}) (keys []interface{}, vals []interface{}) {
+
+	defer func() {
+		if err := recover(); err != nil {
+			panic(map[string]interface{}{
+				"funcion": "KeysValuesMap - Unhandled Error!",
+				"err":     err,
+				"status":  "500",
+			})
+		}
+	}()
+
+	for k, v := range m {
+		keys = append(keys, k)
+		vals = append(vals, v)
+	}
+	return
+}

--- a/helpers/utilsHelper/utilsHelper.helper.go
+++ b/helpers/utilsHelper/utilsHelper.helper.go
@@ -70,6 +70,10 @@ func ConvertirStringJson(Objeto_ interface{}) (Salida map[string]interface{}, er
 // ArrayFind
 func ArrayFind(Objeto__ []map[string]interface{}, campo string, valor string) (Busqueda map[string]interface{}, err error) {
 
+	if len(Objeto__) == 0 {
+		return nil, nil
+	}
+
 	Busqueda_ := make(map[string]interface{}, 0)
 	if keys := len(Objeto__[0]); keys != 0 {
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -89,8 +89,8 @@
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "id",
-                        "description": "id del acta",
+                        "name": "tipo",
+                        "description": "Estado del acta",
                         "required": true,
                         "type": "string"
                     }

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -61,8 +61,8 @@ paths:
       operationId: ActaRecibidoController.GetActasRecibidoTipo
       parameters:
       - in: path
-        name: id
-        description: id del acta
+        name: tipo
+        description: Estado del acta
         required: true
         type: string
       responses:


### PR DESCRIPTION
Se reescribió la consulta de actas, de tal manera que el filtrado de actas por estados y/o roles se intente hacer "antes" de traer las actas, y no después, que fué como se desarrolló en #53

El "antes" mediante una estrategia para traer las actas a partir de los roles y/o estados especificados

Esto está relacionado con udistrital/arka_cliente#521