### PR TITLE
Fix/actas proveedor

### DIFF
--- a/helpers/actaRecibido/actaRecibdo.helper.go
+++ b/helpers/actaRecibido/actaRecibdo.helper.go
@@ -42,7 +42,6 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	var Historico []map[string]interface{}
 	Terceros := make(map[int](map[string]interface{}))
 	Ubicaciones := make(map[int](map[string]interface{}))
-	Proveedores := make(map[int](*models.Proveedor))
 
 	consultasTerceros := 0
 	consultasUbicaciones := 0
@@ -58,7 +57,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 	proveedor := false
 	contratista := false
 	idTercero := 0
-	idProveedor := 0 // TODO: Eliminar esta variable cuando se pasen los proveedores a Terceros, usar solo idTercero
+
 	// De especificarse un usuario, hay que definir las actas que puede ver
 	if usrWSO2 != "" {
 
@@ -127,9 +126,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 					contratista = true
 				}
 			}
-			// TODO: Debería ser suficiente cambiar la condicion por 'proveedor || contratista'
-			// una vez se decida cargar los proveedores también de terceros
-			if contratista && idTercero == 0 {
+			if proveedor || contratista {
 				if data, err := tercerosHelper.GetTerceroByUsuarioWSO2(usrWSO2); err == nil {
 					if v, ok := data["Id"].(int); ok {
 						idTercero = v
@@ -139,22 +136,9 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 					return nil, err
 				}
 			}
-			// TODO: Eliminar el siguiente bloque cuando se pasen los proveedores a Terceros
-			// (Debería ser suficiente con el bloque anterior, idTercero)
-			if proveedor && idProveedor == 0 {
-				// 1. A partir del documento obtenido de WSO2, buscar el proveedor
-				consultasProveedores++
-				if data, err := proveedorHelper.GetProveedorByDoc(usr.Documento); err == nil {
-					idProveedor = data.Id
-					Proveedores[idProveedor] = data
-				} else {
-					return nil, err
-				}
-			}
 		}
 	}
 	logs.Info("u:", usrWSO2, "- t:", verTodasLasActas, "- e:", algunosEstados, "- p:", proveedor, "- c:", contratista, "- i:", idTercero)
-	logs.Info("iP:", idProveedor)
 
 	// fmt.Print("Estados Solicitados: ")
 	// fmt.Println(states)
@@ -282,7 +266,7 @@ func GetAllActasRecibidoActivas(states []string, usrWSO2 string) (historicoActa 
 				urlSoporteActa := "http://" + beego.AppConfig.String("actaRecibidoService") + "soporte_acta"
 				urlSoporteActa += "?fields=Id" // Realmente no importan los campos, lo que importa es la asociacion con el proveedor y el acta
 				urlSoporteActa += "&query=Activo:true,ActaRecibidoId__Id:" + fmt.Sprint(idActa)
-				urlSoporteActa += ",ProveedorId:" + fmt.Sprint(idProveedor) // TODO: Cambiar por idTercero cuando sea el momento
+				urlSoporteActa += ",ProveedorId:" + fmt.Sprint(idTercero)
 				// logs.Debug("urlSoporteActa:", urlSoporteActa)
 				if resp, err := request.GetJsonTest(urlSoporteActa, &soportes); err == nil && resp.StatusCode == 200 {
 					if len(soportes) >= 1 {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -981,14 +981,18 @@
             "title": "AsignacionEspacioFisicoDependencia",
             "type": "object",
             "properties": {
+                "Activo": {
+                    "type": "boolean"
+                },
                 "DependenciaId": {
                     "$ref": "#/definitions/models.Dependencia"
                 },
+                "DocumentoSoporte": {
+                    "type": "integer",
+                    "format": "int64"
+                },
                 "EspacioFisicoId": {
                     "$ref": "#/definitions/models.EspacioFisico"
-                },
-                "Estado": {
-                    "type": "string"
                 },
                 "FechaFin": {
                     "type": "string",
@@ -1373,11 +1377,19 @@
             "title": "EspacioFisico",
             "type": "object",
             "properties": {
-                "Codigo": {
+                "Activo": {
+                    "type": "boolean"
+                },
+                "CodigoAbreviacion": {
                     "type": "string"
                 },
-                "Estado": {
-                    "type": "string"
+                "FechaCreacion": {
+                    "type": "string",
+                    "format": "datetime"
+                },
+                "FechaModificacion": {
+                    "type": "string",
+                    "format": "datetime"
                 },
                 "Id": {
                     "type": "integer",
@@ -1872,6 +1884,20 @@
             "title": "TipoEspacio",
             "type": "object",
             "properties": {
+                "Activo": {
+                    "type": "boolean"
+                },
+                "CodigoAbreviacion": {
+                    "type": "string"
+                },
+                "FechaCreacion": {
+                    "type": "string",
+                    "format": "datetime"
+                },
+                "FechaModificacion": {
+                    "type": "string",
+                    "format": "datetime"
+                },
                 "Id": {
                     "type": "integer",
                     "format": "int64"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -657,12 +657,15 @@ definitions:
     title: AsignacionEspacioFisicoDependencia
     type: object
     properties:
+      Activo:
+        type: boolean
       DependenciaId:
         $ref: '#/definitions/models.Dependencia'
+      DocumentoSoporte:
+        type: integer
+        format: int64
       EspacioFisicoId:
         $ref: '#/definitions/models.EspacioFisico'
-      Estado:
-        type: string
       FechaFin:
         type: string
         format: datetime
@@ -936,10 +939,16 @@ definitions:
     title: EspacioFisico
     type: object
     properties:
-      Codigo:
+      Activo:
+        type: boolean
+      CodigoAbreviacion:
         type: string
-      Estado:
+      FechaCreacion:
         type: string
+        format: datetime
+      FechaModificacion:
+        type: string
+        format: datetime
       Id:
         type: integer
         format: int64
@@ -1285,6 +1294,16 @@ definitions:
     title: TipoEspacio
     type: object
     properties:
+      Activo:
+        type: boolean
+      CodigoAbreviacion:
+        type: string
+      FechaCreacion:
+        type: string
+        format: datetime
+      FechaModificacion:
+        type: string
+        format: datetime
       Id:
         type: integer
         format: int64


### PR DESCRIPTION
En `acta_recibido/get_all_actas` el ID del proveedor ahora se valida contra Terceros, en vez de Proveedores (administrativa)

Relacionado con udistrital/arka_cliente#551

Otro: swagger actualizado (de manera automática, seguramente faltó incluirlo en commits anteriores)