### PR TITLE
Fix: consultar cuentas subgrupo

### DIFF
--- a/helpers/catalogoElementosHelper/catalogoElementos.helper.go
+++ b/helpers/catalogoElementosHelper/catalogoElementos.helper.go
@@ -63,19 +63,18 @@ func GetCuentasContablesSubgrupo(subgrupoId int) (cuentasSubgrupoTransaccion []m
 	}
 
 	var cuentasSubgrupo []*models.CuentaSubgrupo
-	var cuentaCredito map[string]interface{}
-	var cuentaDebito map[string]interface{}
 
 	urlcrud := "http://" + beego.AppConfig.String("catalogoElementosService") + "cuentas_subgrupo?limit=-1"
 	urlcrud += "&query=Activo:True,SubgrupoId.Id:" + strconv.Itoa(int(subgrupoId))
-	logs.Debug("urlcrud:", urlcrud)
+	// logs.Debug("urlcrud:", urlcrud)
 
 	if response, err := request.GetJsonTest(urlcrud, &cuentasSubgrupo); err == nil && response.StatusCode == 200 { // (2) error servicio caido
-		fmt.Println(cuentasSubgrupo[0])
+		// fmt.Println(cuentasSubgrupo[0])
 		if cuentasSubgrupo[0].Id != 0 {
 			for _, cuenta := range cuentasSubgrupo {
-				cuentaCredito, outputError = cuentasContablesHelper.GetCuentaContable(cuenta.CuentaCreditoId)
-				cuentaDebito, outputError = cuentasContablesHelper.GetCuentaContable(cuenta.CuentaDebitoId)
+				// logs.Debug("CuentaCreditoId:", cuenta.CuentaCreditoId, " - CuentaDebitoId:", cuenta.CuentaDebitoId)
+				cuentaCredito, _ := cuentasContablesHelper.GetCuentaContable(cuenta.CuentaCreditoId)
+				cuentaDebito, _ := cuentasContablesHelper.GetCuentaContable(cuenta.CuentaDebitoId)
 
 				cuentasSubgrupoTransaccion = append(cuentasSubgrupoTransaccion, map[string]interface{}{
 					"Id":                  cuenta.Id,

--- a/helpers/cuentasContablesHelper/cuentasContables.helper.go
+++ b/helpers/cuentasContablesHelper/cuentasContables.helper.go
@@ -1,6 +1,8 @@
 package cuentasContablesHelper
 
 import (
+	"fmt"
+
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/logs"
 
@@ -13,7 +15,7 @@ func GetCuentaContable(cuentaContableId string) (cuentaContable map[string]inter
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "GetCuentaContableByCodigo - Unhandled Error!",
+				"funcion": "GetCuentaContable - Unhandled Error!",
 				"err":     err,
 				"status":  "500",
 			}
@@ -25,18 +27,20 @@ func GetCuentaContable(cuentaContableId string) (cuentaContable map[string]inter
 		urlcrud string
 	)
 	urlcrud = "http://" + beego.AppConfig.String("cuentasContablesService") + "cuenta_contable/" + cuentaContableId
+	logs.Debug("urlcrud:", urlcrud)
 
-	if response, err := request.GetJsonTest(urlcrud, &cuentaContable); err == nil { // (2) error servicio caido
-		if response.StatusCode == 200 { // (3) error estado de la solicitud
-			return cuentaContable, nil
-		} else {
-			logs.Info("Error (3) estado de la solicitud")
-			outputError = map[string]interface{}{"Function": "GetCuentasContablesGrupo:GetCuentasContablesGrupo", "Error": response.Status}
-			return nil, outputError
-		}
+	if response, err := request.GetJsonTest(urlcrud, &cuentaContable); err == nil && response.StatusCode == 200 {
+		return cuentaContable, nil
 	} else {
-		logs.Info("Error (2) servicio caido")
-		outputError = map[string]interface{}{"Function": "GetCuentasContablesGrupo", "Error": err}
+		if err == nil {
+			err = fmt.Errorf("Undesired Status Code: %d", response.StatusCode)
+		}
+		logs.Error(err)
+		outputError = map[string]interface{}{
+			"funcion": "GetCuentaContable - request.GetJsonTest(urlcrud, &cuentaContable)",
+			"err":     err,
+			"status":  "502",
+		}
 		return nil, outputError
 	}
 }

--- a/helpers/cuentasContablesHelper/cuentasContables.helper.go
+++ b/helpers/cuentasContablesHelper/cuentasContables.helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/logs"
 
+	"github.com/udistrital/arka_mid/models"
 	"github.com/udistrital/utils_oas/request"
 )
 
@@ -23,17 +24,19 @@ func GetCuentaContable(cuentaContableId string) (cuentaContable map[string]inter
 		}
 	}()
 
-	var (
-		urlcrud string
-	)
-	urlcrud = "http://" + beego.AppConfig.String("cuentasContablesService") + "cuenta_contable/" + cuentaContableId
-	logs.Debug("urlcrud:", urlcrud)
+	urlcrud := "http://" + beego.AppConfig.String("cuentasContablesService") + "nodo_cuenta_contable/" + cuentaContableId
+	// logs.Debug("urlcrud:", urlcrud)
 
-	if response, err := request.GetJsonTest(urlcrud, &cuentaContable); err == nil && response.StatusCode == 200 {
-		return cuentaContable, nil
+	var data models.RespuestaAPI2obj
+	if resp, err := request.GetJsonTest(urlcrud, &data); err == nil && resp.StatusCode == 200 && data.Code == 200 {
+		return data.Body, nil
 	} else {
 		if err == nil {
-			err = fmt.Errorf("Undesired Status Code: %d", response.StatusCode)
+			if resp.StatusCode != 200 {
+				err = fmt.Errorf("Undesired Status Code: %d", resp.StatusCode)
+			} else {
+				err = fmt.Errorf("Undesired Status Code: %d - in Body: %d", resp.StatusCode, data.Code)
+			}
 		}
 		logs.Error(err)
 		outputError = map[string]interface{}{

--- a/models/respuestas_APIs.go
+++ b/models/respuestas_APIs.go
@@ -23,3 +23,25 @@ type RespuestaAPI1Arr struct {
 	RespuestaAPI1
 	Data []map[string]interface{}
 }
+
+// RespuestaAPI2 es similar a RespuestaAPI1
+// Agrupa las estructuras comunes y por lo mismo
+// NO se debe usar directamente
+type RespuestaAPI2 struct {
+	Code    int
+	Message string
+}
+
+// RespuestaAPI2obj es un RespuestaAPI2 donde
+// el Body es un objeto
+type RespuestaAPI2obj struct {
+	RespuestaAPI2
+	Body map[string]interface{}
+}
+
+// RespuestaAPI2arr es un RespuestaAPI2 donde
+// el Body es un arreglo
+type RespuestaAPI2arr struct {
+	RespuestaAPI2
+	Body []map[string]interface{}
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -462,6 +462,16 @@
                 ],
                 "description": "Devuelve las todas las actas de recibido",
                 "operationId": "CatalogoElementosController.GetCuentasSubgrupoById",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "subgroup id",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "",

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -321,6 +321,13 @@ paths:
       - catalogo_elementos
       description: Devuelve las todas las actas de recibido
       operationId: CatalogoElementosController.GetCuentasSubgrupoById
+      parameters:
+      - in: path
+        name: id
+        description: subgroup id
+        required: true
+        type: integer
+        format: int64
       responses:
         "200":
           description: ""


### PR DESCRIPTION
Para el endpoint `/catalogo_elementos/cuentas_contables/{id}`

- Faltaba el parámetro del ID --> se actualizó el swagger
- Al cambiar de financiera API a cuentas API, cambió el modelo de datos de la respuesta (ahora va encapsulada en un `Body`). Se ajustó para que desde dentro de la petición se desencapsule y retornar así una estructura similar a la original que demanda el cliente (desde Catalogo>Consultar, a nivel de clase)

Relacionado con udistrital/arka_cliente#608

