### PR TITLE
Fix/bodega

### DIFF
--- a/controllers/bodega_consumo.go
+++ b/controllers/bodega_consumo.go
@@ -158,9 +158,13 @@ func (c *BodegaConsumoController) GetAllExistencias() {
 	if v, err := bodegaConsumoHelper.GetExistenciasKardex(); err != nil {
 		panic(err)
 	} else {
-		c.Data["json"] = v
+		if len(v) == 0 || v == nil {
+			c.Ctx.Output.Body([]byte("[]"))
+		} else {
+			c.Data["json"] = v
+			c.ServeJSON()
+		}
 	}
-	c.ServeJSON()
 }
 
 // Put ...

--- a/helpers/bajasHelper/bajasHelper.helper.go
+++ b/helpers/bajasHelper/bajasHelper.helper.go
@@ -118,7 +118,7 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 	defer func() {
 		if err := recover(); err != nil {
 			outputError = map[string]interface{}{
-				"funcion": "/GetAllSolicitudes",
+				"funcion": "GetAllSolicitudes - Uncaught Error!",
 				"err":     err,
 				"status":  "500",
 			}
@@ -138,7 +138,7 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 		if len(Solicitudes) == 0 || len(Solicitudes[0]) == 0 {
 			logs.Warn(err)
 			outputError = map[string]interface{}{
-				"funcion": "/GetAllSolicitudes",
+				"funcion": "GetAllSolicitudes - len(Solicitudes) == 0 || len(Solicitudes[0]) == 0",
 				"err":     "sin",
 				"status":  "200", // TODO: Debería ser un 204 pero el cliente (Angular) se ofende... (hay que hacer varios ajustes)
 			}
@@ -161,7 +161,7 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 			} else {
 				logs.Error(err)
 				outputError = map[string]interface{}{
-					"funcion": "/GetAllSolicitudes",
+					"funcion": "GetAllSolicitudes - utilsHelper.ConvertirStringJson(solicitud[\"Detalle\"])",
 					"err":     err,
 					"status":  "500",
 				}
@@ -172,7 +172,7 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 			} else {
 				logs.Error(err)
 				outputError = map[string]interface{}{
-					"funcion": "/GetAllSolicitudes",
+					"funcion": "GetAllSolicitudes - utilsHelper.ConvertirInterfaceMap(solicitud[\"EstadoMovimientoId\"])",
 					"err":     err,
 					"status":  "500",
 				}
@@ -183,8 +183,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 				if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Funcionario"])); err == nil {
 					Tercero_ = Tercero
 					Terceros = append(Terceros, Tercero)
-				} else {
-					return nil, err
+					// } else {
+					// 	return nil, err
 				}
 			} else {
 				if keys := len(Terceros[0]); keys != 0 {
@@ -193,8 +193,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 							if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Funcionario"])); err == nil {
 								Tercero_ = Tercero
 								Terceros = append(Terceros, Tercero)
-							} else {
-								return nil, err
+								// } else {
+								// 	return nil, err
 							}
 						} else {
 							Tercero_ = Tercero
@@ -212,8 +212,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 					if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Revisor"])); err == nil {
 						Tercero_ = Tercero
 						Terceros = append(Terceros, Tercero)
-					} else {
-						return nil, err
+						// } else {
+						// 	return nil, err
 					}
 				}
 			}
@@ -222,8 +222,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 				if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Revisor"])); err == nil {
 					Revisor_ = Tercero
 					Terceros = append(Terceros, Tercero)
-				} else {
-					return nil, err
+					// } else {
+					// 	return nil, err
 				}
 			} else {
 				if keys := len(Terceros[0]); keys != 0 {
@@ -232,8 +232,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 							if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Revisor"])); err == nil {
 								Revisor_ = Tercero
 								Terceros = append(Terceros, Tercero)
-							} else {
-								return nil, err
+								// } else {
+								// 	return nil, err
 							}
 						} else {
 							Revisor_ = Tercero
@@ -251,8 +251,8 @@ func GetAllSolicitudes() (historicoActa []map[string]interface{}, outputError ma
 					if Tercero, err := tercerosHelper.GetNombreTerceroById(fmt.Sprintf("%v", data_["Revisor"])); err == nil {
 						Revisor_ = Tercero
 						Terceros = append(Terceros, Tercero)
-					} else {
-						return nil, err
+						// } else {
+						// 	return nil, err
 					}
 				}
 			}

--- a/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
+++ b/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
@@ -489,8 +489,6 @@ func GetExistenciasKardex() (Elementos []map[string]interface{}, outputError map
 
 				if Elemento, err := UltimoMovimientoKardex(idCatalogo); err == nil {
 					Elementos = append(Elementos, Elemento)
-				} else {
-					return nil, err
 				}
 			}
 
@@ -546,6 +544,17 @@ func UltimoMovimientoKardex(id_catalogo int) (Elemento_Movimiento map[string]int
 	url3 := "http://" + beego.AppConfig.String("catalogoElementosService") + "elemento?query=Id:" + idStr
 	// logs.Debug("url3:", url3)
 	if res, err := request.GetJsonTest(url3, &elemento_catalogo); err == nil && res.StatusCode == 200 {
+
+		if len(elemento_catalogo) != 1 || len(elemento_catalogo[0]) == 0 {
+			err = fmt.Errorf("No hay un elemento del Catalogo de Elementos con id:%s", idStr)
+			logs.Error(err)
+			outputError = map[string]interface{}{
+				"funcion": "UltimoMovimientoKardex - len(elemento_catalogo) != 1 || len(elemento_catalogo[0]) == 0",
+				"err":     err,
+				"status":  "404",
+			}
+			return nil, outputError
+		}
 
 		// fmt.Println(elemento_catalogo)
 		var ultimo_movimiento_kardex []map[string]interface{}

--- a/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
+++ b/helpers/bodegaConsumoHelper/bodegaConsumo.helper.go
@@ -488,7 +488,11 @@ func GetExistenciasKardex() (Elementos []map[string]interface{}, outputError map
 				}
 
 				if Elemento, err := UltimoMovimientoKardex(idCatalogo); err == nil {
-					Elementos = append(Elementos, Elemento)
+					if s, ok := Elemento["SaldoCantidad"]; ok {
+						if v, ok := s.(float64); ok && v > 0 {
+							Elementos = append(Elementos, Elemento)
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
El endpoint `bodega_consumo/existencias_kardex` se usa en el Cliente en Bodega de Consumo > Solicitar Elementos.

Ahora los resultados retornados:
- Están asociados a un elemento de la API de Catálogo de Elementos
- Solo se muestran si hay uno o más elementos

Así, el solicitante no podrá escoger elementos inconsistentes por Catalogo o existencias

Relacionado con udistrital/arka_cliente#596