### PR TITLE
fix: filtroActas.go borrado en 74f0c97f7a, restaurado de bfaf5a315

### DIFF
--- a/helpers/actaRecibido/filtroActas.go
+++ b/helpers/actaRecibido/filtroActas.go
@@ -1,0 +1,28 @@
+// Este archivo se borró erróneamente en el commit 74f0c97f7
+// Para ver la historia antes de haberlo borrado, referirse
+// al commit bfaf5a315, que fue el último antes de borrarlo
+
+package actaRecibido
+
+import (
+	"github.com/udistrital/arka_mid/models"
+)
+
+// Mapeo con los roles que pueden ver TODAS las actas en dicho estado
+// Llaves: estados válidos de Actas
+// Valores: mapeables desde models.RolesArka
+var reglasVerTodas = map[string][]string{
+	"Registrada":         {models.RolesArka["Secretaria"]},
+	"En Elaboracion":     {},
+	"En Modificacion":    {},
+	"En verificacion":    {},
+	"Aceptada":           {},
+	"Asociada a Entrada": {},
+	"Anulada":            {},
+}
+
+// Arreglo de roles que pueden ver actas en cualquier estado
+var verCualquierEstado = []string{
+	models.RolesArka["Admin"],
+	models.RolesArka["Revisor"],
+}


### PR DESCRIPTION
Este archivo se borró erróneamente en el commit 74f0c97f7
Para ver la historia antes de haberlo borrado, referirse al commit bfaf5a315, que fue el último antes de borrarlo